### PR TITLE
Add content_length to WSGI environ

### DIFF
--- a/granian/_granian.pyi
+++ b/granian/_granian.pyi
@@ -78,3 +78,4 @@ class WSGIScope:
     query_string: str
     headers: Dict[str, str]
     body: bytes
+    length: int

--- a/granian/wsgi.py
+++ b/granian/wsgi.py
@@ -44,7 +44,8 @@ def _callback_wrapper(callback):
             'QUERY_STRING': scope.query_string,
             'REMOTE_ADDR': scope.client,
             'wsgi.url_scheme': scope.scheme,
-            'wsgi.input': scope.body
+            'wsgi.input': scope.body,
+            "CONTENT_LENGTH": scope.length
         }
         resp = Response()
 

--- a/tests/apps/wsgi.py
+++ b/tests/apps/wsgi.py
@@ -11,6 +11,7 @@ def info(environ, protocol):
         'method': environ['REQUEST_METHOD'],
         'path': environ["PATH_INFO"],
         'query_string': environ["QUERY_STRING"],
+        'content_length': environ['CONTENT_LENGTH'],
         'headers': {k: v for k, v in environ.items() if k.startswith("HTTP_")}
     }).encode("utf8")]
 

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -11,18 +11,21 @@ import pytest
     ]
 )
 async def test_scope(wsgi_server, threading_mode):
+    payload = "body_payload"
     async with wsgi_server(threading_mode) as port:
-        res = httpx.get(f"http://localhost:{port}/info?test=true")
+        res = httpx.post(f"http://localhost:{port}/info?test=true", data=payload)
 
     assert res.status_code == 200
     assert res.headers["content-type"] == "application/json"
 
     data = res.json()
     assert data['scheme'] == 'http'
-    assert data['method'] == "GET"
+    assert data['method'] == "POST"
     assert data['path'] == '/info'
     assert data['query_string'] == 'test=true'
     assert data['headers']['HTTP_HOST'] == f'localhost:{port}'
+    assert data['content_length'] == len(payload)
+
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
According to PEP333 `CONTENT_LENGTH` variable is optional but it also says:
> The application should not attempt to read more data than is specified by the CONTENT_LENGTH variable.  

So most implementations assume length is 0 if header is missing.
See for details: https://wsgi.readthedocs.io/en/latest/proposals-2.0.html#unknown-length-wsgi-input

As for the fix itself i'm not sure if is correct. Could just grab length in python?