### PR TITLE
Fix: Missing argument for handler in send

### DIFF
--- a/granian/asgi.py
+++ b/granian/asgi.py
@@ -98,7 +98,7 @@ class LifespanProtocol:
 
     async def send(self, message):
         handler = self._event_handlers[message["type"]]
-        handler(message)
+        handler(self, message)
 
 
 def _noop_wrapper(proto):


### PR DESCRIPTION
The unbound methods are stored in the class method _event_handlers, which means we have to provide
the self argument.

Closes #37