### PR TITLE
Enables dependabot for Cargo and Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#package-ecosystem
+
+version: 2
+updates:
+  # Enable updates for Github Actions
+  - package-ecosystem: "github-actions"
+    target-branch: "master"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every month
+      interval: "monthly"
+  # Enable updates for Cargo
+  - package-ecosystem: "cargo"
+    target-branch: "master"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Hopefully this is something useful to help keep dependencies up to date with a little less manual work.  

This enables dependabot for the Cargo and GitHub Actions ecosystems, checking at a monthly interval (configurable).  I don't believe there is anything required besides the inclusion of this file to enable dependabot.