### PR TITLE
Optional logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Options:
   --backlog INTEGER RANGE         Maximum number of connections to hold in
                                   backlog.  [env var: GRANIAN_BACKLOG;
                                   default: 1024; x>=128]
+                                  backlog.  [default: 1024; x>=128]
+  --log / --no-log                Enable logging  [default: (enabled)]
   --log-level [critical|error|warning|warn|info|debug]
                                   Log level  [env var: GRANIAN_LOG_LEVEL;
                                   default: info]

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Options:
   --backlog INTEGER RANGE         Maximum number of connections to hold in
                                   backlog.  [env var: GRANIAN_BACKLOG;
                                   default: 1024; x>=128]
-                                  backlog.  [default: 1024; x>=128]
-  --log / --no-log                Enable logging  [default: (enabled)]
+  --log / --no-log                Enable logging  [env var:
+                                  GRANIAN_LOG_ENABLED; default: (enabled)]
   --log-level [critical|error|warning|warn|info|debug]
                                   Log level  [env var: GRANIAN_LOG_LEVEL;
                                   default: info]

--- a/granian/cli.py
+++ b/granian/cli.py
@@ -33,12 +33,7 @@ def main(
     loop: Loops = typer.Option(Loops.auto.value, help='Event loop implementation'),
     loop_opt: bool = typer.Option(False, '--opt/--no-opt', help='Enable loop optimizations', show_default='disabled'),
     backlog: int = typer.Option(1024, min=128, help='Maximum number of connections to hold in backlog.'),
-    log: bool = typer.Option(
-        True,
-        "--log/--no-log",
-        help="",
-        show_default="enabled"
-    ),
+    log_enabled: bool = typer.Option(True, "--log/--no-log", help='Enable logging', show_default='enabled'),
     log_level: LogLevels = typer.Option(LogLevels.info.value, help='Log level', case_sensitive=False),
     log_config: Optional[Path] = typer.Option(
         None, help='Logging configuration file (json)', exists=True, file_okay=True, dir_okay=False, readable=True
@@ -85,7 +80,7 @@ def main(
         http=http,
         websockets=websockets,
         backlog=backlog,
-        log=log,
+        log_enabled=log_enabled,
         log_level=log_level,
         log_dictconfig=log_dictconfig,
         ssl_cert=ssl_certificate,

--- a/granian/cli.py
+++ b/granian/cli.py
@@ -33,7 +33,7 @@ def main(
     loop: Loops = typer.Option(Loops.auto.value, help='Event loop implementation'),
     loop_opt: bool = typer.Option(False, '--opt/--no-opt', help='Enable loop optimizations', show_default='disabled'),
     backlog: int = typer.Option(1024, min=128, help='Maximum number of connections to hold in backlog.'),
-    log_enabled: bool = typer.Option(True, "--log/--no-log", help='Enable logging', show_default='enabled'),
+    log_enabled: bool = typer.Option(True, '--log/--no-log', help='Enable logging', show_default='enabled'),
     log_level: LogLevels = typer.Option(LogLevels.info.value, help='Log level', case_sensitive=False),
     log_config: Optional[Path] = typer.Option(
         None, help='Logging configuration file (json)', exists=True, file_okay=True, dir_okay=False, readable=True

--- a/granian/cli.py
+++ b/granian/cli.py
@@ -33,6 +33,12 @@ def main(
     loop: Loops = typer.Option(Loops.auto.value, help='Event loop implementation'),
     loop_opt: bool = typer.Option(False, '--opt/--no-opt', help='Enable loop optimizations', show_default='disabled'),
     backlog: int = typer.Option(1024, min=128, help='Maximum number of connections to hold in backlog.'),
+    log: bool = typer.Option(
+        True,
+        "--log/--no-log",
+        help="",
+        show_default="enabled"
+    ),
     log_level: LogLevels = typer.Option(LogLevels.info.value, help='Log level', case_sensitive=False),
     log_config: Optional[Path] = typer.Option(
         None, help='Logging configuration file (json)', exists=True, file_okay=True, dir_okay=False, readable=True
@@ -79,6 +85,7 @@ def main(
         http=http,
         websockets=websockets,
         backlog=backlog,
+        log=log,
         log_level=log_level,
         log_dictconfig=log_dictconfig,
         ssl_cert=ssl_certificate,

--- a/granian/log.py
+++ b/granian/log.py
@@ -26,7 +26,6 @@ log_levels_map = {
 LOGGING_CONFIG = {
     'version': 1,
     'disable_existing_loggers': False,
-    'root': {'level': 'INFO', 'handlers': ['console']},
     'formatters': {
         'generic': {
             '()': 'logging.Formatter',
@@ -35,10 +34,11 @@ LOGGING_CONFIG = {
         }
     },
     'handlers': {'console': {'formatter': 'generic', 'class': 'logging.StreamHandler', 'stream': 'ext://sys.stdout'}},
+    'loggers': {'_granian': {'handlers': ['console'], 'level': 'INFO', 'propagate': False}},
 }
 
 # NOTE: to be consistent with the Rust module logger name
-logger = logging.getLogger("_granian")
+logger = logging.getLogger('_granian')
 
 
 def configure_logging(level: LogLevels, config: Optional[Dict[str, Any]] = None, enabled: bool = True):
@@ -46,7 +46,8 @@ def configure_logging(level: LogLevels, config: Optional[Dict[str, Any]] = None,
 
     if config:
         log_config.update(config)
-    log_config['root']['level'] = log_levels_map[level]
+
+    log_config['loggers']['_granian']['level'] = log_levels_map[level]
     logging.config.dictConfig(log_config)
 
     if not enabled:

--- a/granian/log.py
+++ b/granian/log.py
@@ -37,12 +37,17 @@ LOGGING_CONFIG = {
     'handlers': {'console': {'formatter': 'generic', 'class': 'logging.StreamHandler', 'stream': 'ext://sys.stdout'}},
 }
 
-logger = logging.getLogger()
+# NOTE: to be consistent with the Rust module logger name
+logger = logging.getLogger("_granian")
 
 
-def configure_logging(level: LogLevels, config: Optional[Dict[str, Any]] = None):
+def configure_logging(level: LogLevels, config: Optional[Dict[str, Any]] = None, enabled: bool = True):
     log_config = copy.deepcopy(LOGGING_CONFIG)
+
     if config:
         log_config.update(config)
     log_config['root']['level'] = log_levels_map[level]
     logging.config.dictConfig(log_config)
+
+    if not enabled:
+        logger.setLevel(logging.CRITICAL + 1)

--- a/granian/server.py
+++ b/granian/server.py
@@ -43,6 +43,7 @@ class Granian:
         websockets: bool = True,
         backlog: int = 1024,
         http1_buffer_size: int = 65535,
+        log: bool = True,
         log_level: LogLevels = LogLevels.info,
         log_dictconfig: Optional[Dict[str, Any]] = None,
         ssl_cert: Optional[Path] = None,
@@ -64,11 +65,15 @@ class Granian:
         self.websockets = websockets
         self.backlog = max(128, backlog)
         self.http1_buffer_size = http1_buffer_size
+        self.log = log
         self.log_level = log_level
         self.log_config = log_dictconfig
         self.url_path_prefix = url_path_prefix
         self.reload_on_changes = reload
-        configure_logging(self.log_level, self.log_config)
+
+        if self.log:
+            configure_logging(self.log_level, self.log_config)
+
         self.build_ssl_context(ssl_cert, ssl_key)
         self._shd = None
         self._sfd = None
@@ -101,6 +106,7 @@ class Granian:
         http1_buffer_size,
         websockets,
         loop_opt,
+        log,
         log_level,
         log_config,
         ssl_ctx,
@@ -108,7 +114,9 @@ class Granian:
     ):
         from granian._loops import loops, set_loop_signals
 
-        configure_logging(log_level, log_config)
+        if log:
+            configure_logging(log_level, log_config)
+
         loop = loops.get(loop_impl)
         sfd = socket.fileno()
         callback = callback_loader()
@@ -144,6 +152,7 @@ class Granian:
         http1_buffer_size,
         websockets,
         loop_opt,
+        log,
         log_level,
         log_config,
         ssl_ctx,
@@ -151,7 +160,9 @@ class Granian:
     ):
         from granian._loops import loops, set_loop_signals
 
-        configure_logging(log_level, log_config)
+        if log:
+            configure_logging(log_level, log_config)
+
         loop = loops.get(loop_impl)
         sfd = socket.fileno()
         target = callback_loader()
@@ -187,6 +198,7 @@ class Granian:
         http1_buffer_size,
         websockets,
         loop_opt,
+        log,
         log_level,
         log_config,
         ssl_ctx,
@@ -194,7 +206,9 @@ class Granian:
     ):
         from granian._loops import loops, set_loop_signals
 
-        configure_logging(log_level, log_config)
+        if log:
+            configure_logging(log_level, log_config)
+
         loop = loops.get(loop_impl)
         sfd = socket.fileno()
         callback = callback_loader()
@@ -228,6 +242,7 @@ class Granian:
                 self.http1_buffer_size,
                 self.websockets,
                 self.loop_opt,
+                self.log,
                 self.log_level,
                 self.log_config,
                 self.ssl_ctx,

--- a/granian/server.py
+++ b/granian/server.py
@@ -43,7 +43,7 @@ class Granian:
         websockets: bool = True,
         backlog: int = 1024,
         http1_buffer_size: int = 65535,
-        log: bool = True,
+        log_enabled: bool = True,
         log_level: LogLevels = LogLevels.info,
         log_dictconfig: Optional[Dict[str, Any]] = None,
         ssl_cert: Optional[Path] = None,
@@ -65,13 +65,13 @@ class Granian:
         self.websockets = websockets
         self.backlog = max(128, backlog)
         self.http1_buffer_size = http1_buffer_size
-        self.log = log
+        self.log_enabled = log_enabled
         self.log_level = log_level
         self.log_config = log_dictconfig
         self.url_path_prefix = url_path_prefix
         self.reload_on_changes = reload
 
-        configure_logging(self.log_level, self.log_config, self.log)
+        configure_logging(self.log_level, self.log_config, self.log_enabled)
 
         self.build_ssl_context(ssl_cert, ssl_key)
         self._shd = None
@@ -105,7 +105,7 @@ class Granian:
         http1_buffer_size,
         websockets,
         loop_opt,
-        log,
+        log_enabled,
         log_level,
         log_config,
         ssl_ctx,
@@ -113,7 +113,7 @@ class Granian:
     ):
         from granian._loops import loops, set_loop_signals
 
-        configure_logging(log_level, log_config, log)
+        configure_logging(log_level, log_config, log_enabled)
 
         loop = loops.get(loop_impl)
         sfd = socket.fileno()
@@ -150,7 +150,7 @@ class Granian:
         http1_buffer_size,
         websockets,
         loop_opt,
-        log,
+        log_enabled,
         log_level,
         log_config,
         ssl_ctx,
@@ -158,7 +158,7 @@ class Granian:
     ):
         from granian._loops import loops, set_loop_signals
 
-        configure_logging(log_level, log_config, log)
+        configure_logging(log_level, log_config, log_enabled)
 
         loop = loops.get(loop_impl)
         sfd = socket.fileno()
@@ -195,7 +195,7 @@ class Granian:
         http1_buffer_size,
         websockets,
         loop_opt,
-        log,
+        log_enabled,
         log_level,
         log_config,
         ssl_ctx,
@@ -203,7 +203,7 @@ class Granian:
     ):
         from granian._loops import loops, set_loop_signals
 
-        configure_logging(log_level, log_config, log)
+        configure_logging(log_level, log_config, log_enabled)
 
         loop = loops.get(loop_impl)
         sfd = socket.fileno()
@@ -238,7 +238,7 @@ class Granian:
                 self.http1_buffer_size,
                 self.websockets,
                 self.loop_opt,
-                self.log,
+                self.log_enabled,
                 self.log_level,
                 self.log_config,
                 self.ssl_ctx,

--- a/granian/server.py
+++ b/granian/server.py
@@ -71,8 +71,7 @@ class Granian:
         self.url_path_prefix = url_path_prefix
         self.reload_on_changes = reload
 
-        if self.log:
-            configure_logging(self.log_level, self.log_config)
+        configure_logging(self.log_level, self.log_config, self.log)
 
         self.build_ssl_context(ssl_cert, ssl_key)
         self._shd = None
@@ -114,8 +113,7 @@ class Granian:
     ):
         from granian._loops import loops, set_loop_signals
 
-        if log:
-            configure_logging(log_level, log_config)
+        configure_logging(log_level, log_config, log)
 
         loop = loops.get(loop_impl)
         sfd = socket.fileno()
@@ -160,8 +158,7 @@ class Granian:
     ):
         from granian._loops import loops, set_loop_signals
 
-        if log:
-            configure_logging(log_level, log_config)
+        configure_logging(log_level, log_config, log)
 
         loop = loops.get(loop_impl)
         sfd = socket.fileno()
@@ -206,8 +203,7 @@ class Granian:
     ):
         from granian._loops import loops, set_loop_signals
 
-        if log:
-            configure_logging(log_level, log_config)
+        configure_logging(log_level, log_config, log)
 
         loop = loops.get(loop_impl)
         sfd = socket.fileno()


### PR DESCRIPTION
This PR adds the `--log`/`--no-log` option to CLI and the same argument to the Granian server class. The default value is `enabled`/`True`, so there are no backward compatibility changes. The option/argument simply allows to opt-out from logging to be configured and emit anything.  

Thus, it resolves #101.

Does it look suitable? Don’t hesitate to give any feedback.