### PR TITLE
Fix `make all`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ lint: lint-python lint-rust
 
 .PHONY: test
 test:
-	pytest -v test
+	pytest -v tests
 
 .PHONY: all
 all: format build-dev lint test

--- a/granian/_granian.pyi
+++ b/granian/_granian.pyi
@@ -1,3 +1,4 @@
+# ruff: noqa: I001
 from typing import Any, Dict, List, Optional, Tuple
 
 from ._types import WebsocketMessage

--- a/src/rsgi/io.rs
+++ b/src/rsgi/io.rs
@@ -288,6 +288,12 @@ struct WebsocketInboundCloseMessage {
     kind: usize,
 }
 
+impl Default for WebsocketInboundCloseMessage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl WebsocketInboundCloseMessage {
     pub fn new() -> Self {
         Self {


### PR DESCRIPTION
Various fixes needed to get `make all` working. Looks like pyproject.toml might be the place for some of the ruff/black formatting clashes instead of this patch.