### PR TITLE
Explicitly re-rexport Granian in `__init__.py`

### DIFF
--- a/granian/__init__.py
+++ b/granian/__init__.py
@@ -1,2 +1,2 @@
 from ._granian import __version__  # noqa
-from .server import Granian as Granian  # noqa
+from .server import Granian as Granian

--- a/granian/__init__.py
+++ b/granian/__init__.py
@@ -1,2 +1,2 @@
 from ._granian import __version__  # noqa
-from .server import Granian  # noqa
+from .server import Granian as Granian  # noqa


### PR DESCRIPTION
### Background
To debug Python ASGI apps it is [common](https://fastapi.tiangolo.com/tutorial/debugging/#debugging) to add some code to your `main.py` file which could look as follows:

```python
if __name__ == "__main__":
    import granian

    granian.Granian("app.main:app", port=8000, interface="asgi", reload=True).serve()
```

While this works perfectly, one now gets an error when running `mypy`:

```
error: Module "granian" does not explicitly export attribute "Granian"  [attr-defined]
```

See also the [mypy docs on this error](https://mypy.readthedocs.io/en/stable/config_file.html#confval-implicit_reexport).

### PR Description
This PR attempts to fix this error by explicitly re-export the class `Granian` within the `__init__.py` file. (AFAIS FastAPI does it the [same way](https://github.com/tiangolo/fastapi/blob/master/fastapi/__init__.py).)

---

P.S. Thanks for the great work on this project! :rocket: 