### PR TITLE
Fallback from `future_into_py_iter` to `future_into_py_futlike` on Linux

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -44,6 +44,7 @@ pub(crate) struct PyIterAwaitable {
     result: RwLock<Option<PyResult<PyObject>>>,
 }
 
+#[cfg(not(target_os = "linux"))]
 impl PyIterAwaitable {
     pub(crate) fn new() -> Self {
         Self {


### PR DESCRIPTION
SSIA