### PR TITLE
Add --respawn-interval option

### DIFF
--- a/granian/cli.py
+++ b/granian/cli.py
@@ -177,6 +177,11 @@ def option(*param_decls: str, cls: Optional[Type[click.Option]] = None, **attrs:
     help='Enable workers respawn on unexpected exit',
 )
 @option(
+    '--respawn-interval',
+    default=3.5,
+    help='The number of seconds to sleep between workers respawn',
+)
+@option(
     '--reload/--no-reload',
     default=False,
     help="Enable auto reload on application's files changes (requires granian[reload] extra)",
@@ -219,6 +224,7 @@ def cli(
     ssl_certificate: Optional[pathlib.Path],
     url_path_prefix: Optional[str],
     respawn_failed_workers: bool,
+    respawn_interval: float,
     reload: bool,
     process_name: Optional[str],
 ) -> None:
@@ -266,6 +272,7 @@ def cli(
         ssl_key=ssl_keyfile,
         url_path_prefix=url_path_prefix,
         respawn_failed_workers=respawn_failed_workers,
+        respawn_interval=respawn_interval,
         reload=reload,
         process_name=process_name,
     ).serve()

--- a/granian/server.py
+++ b/granian/server.py
@@ -87,6 +87,7 @@ class Granian:
         ssl_key: Optional[Path] = None,
         url_path_prefix: Optional[str] = None,
         respawn_failed_workers: bool = False,
+        respawn_interval: float = 3.5,
         reload: bool = False,
         process_name: Optional[str] = None,
     ):
@@ -111,6 +112,7 @@ class Granian:
         self.url_path_prefix = url_path_prefix
         self.respawn_failed_workers = respawn_failed_workers
         self.reload_on_changes = reload
+        self.respawn_interval = respawn_interval
         self.process_name = process_name
 
         configure_logging(self.log_level, self.log_config, self.log_enabled)
@@ -448,7 +450,7 @@ class Granian:
                 self.reload_signal = False
                 self.respawned_procs.clear()
                 self.main_loop_interrupt.clear()
-                self._respawn_workers(workers, sock, spawn_target, target_loader, delay=3.5)
+                self._respawn_workers(workers, sock, spawn_target, target_loader, delay=self.respawn_interval)
 
     def _serve(self, spawn_target, target_loader):
         sock = self.startup(spawn_target, target_loader)


### PR DESCRIPTION
Add --reload-interval [seconds] so that Granian can reload slowly for large applications.

I could not locally test this PR