### PR TITLE
feat: more detailed reload logging

### DIFF
--- a/granian/server.py
+++ b/granian/server.py
@@ -581,8 +581,10 @@ class Granian:
         sock = self.startup(spawn_target, target_loader)
 
         try:
-            for _ in watchfiles.watch(reload_path, stop_event=self.main_loop_interrupt):
+            for changes in watchfiles.watch(reload_path, stop_event=self.main_loop_interrupt):
                 logger.info('Changes detected, reloading workers..')
+                for change, file in changes:
+                    logger.info(f'{change.raw_str().capitalize()}: {file}')
                 self._stop_workers()
                 self._spawn_workers(sock, spawn_target, target_loader)
         except StopIteration:


### PR DESCRIPTION
### Description
Hey,
this PR will add slightly more detail to logging on reloads.

Instead of just logging out
```
[INFO] Changes detected, reloading workers..
```
we would give one line for each change like
```
...
[INFO] Started worker-1
[INFO] Started worker-1 runtime-1
[INFO] Changes detected, reloading workers..
[INFO] Modified: /Users/AmonKhavari/granian/a_cool_file.py
[INFO] Modified: /Users/AmonKhavari/granian/another_cool_one.py
[INFO] Added: /Users/AmonKhavari/granian/something
[INFO] Deleted: /Users/AmonKhavari/granian/something_else
[INFO] Stopping worker-1
[INFO] Stopping worker-1 runtime-1
...
```

I personally think it will contribute to better visibility on potential misconfiguration that a user might face.
Especially if #362 goes to master and things might need some configuration.

However, I realize this is fairly verbose. I figured it's okay since it only logs out on `INFO` level.

Let me know what you think :)