### PR TITLE
Don't shutdown on reload signal(SIGHUP) when using the reloader option 

### DIFF
--- a/granian/server.py
+++ b/granian/server.py
@@ -516,13 +516,12 @@ class Granian:
             self.pid_file.unlink()
 
     def _reload(self, sock, spawn_target, target_loader):
-        if self.reload_signal:
-            logger.info('HUP signal received, gracefully respawning workers..')
-            workers = list(range(self.workers))
-            self.reload_signal = False
-            self.respawned_procs.clear()
-            self.main_loop_interrupt.clear()
-            self._respawn_workers(workers, sock, spawn_target, target_loader, delay=self.respawn_interval)
+        logger.info('HUP signal received, gracefully respawning workers..')
+        workers = list(range(self.workers))
+        self.reload_signal = False
+        self.respawned_procs.clear()
+        self.main_loop_interrupt.clear()
+        self._respawn_workers(workers, sock, spawn_target, target_loader, delay=self.respawn_interval)
 
     def startup(self, spawn_target, target_loader):
         self.pid = os.getpid()
@@ -568,7 +567,8 @@ class Granian:
                 self.main_loop_interrupt.clear()
                 self._respawn_workers(workers, sock, spawn_target, target_loader)
 
-            self._reload(sock, spawn_target, target_loader)
+            if self.reload_signal:
+                self._reload(sock, spawn_target, target_loader)
 
     def _serve(self, spawn_target, target_loader):
         sock = self.startup(spawn_target, target_loader)

--- a/granian/server.py
+++ b/granian/server.py
@@ -515,6 +515,15 @@ class Granian:
         if file_pid == self.pid:
             self.pid_file.unlink()
 
+    def _reload(self, sock, spawn_target, target_loader):
+        if self.reload_signal:
+            logger.info('HUP signal received, gracefully respawning workers..')
+            workers = list(range(self.workers))
+            self.reload_signal = False
+            self.respawned_procs.clear()
+            self.main_loop_interrupt.clear()
+            self._respawn_workers(workers, sock, spawn_target, target_loader, delay=self.respawn_interval)
+
     def startup(self, spawn_target, target_loader):
         self.pid = os.getpid()
         logger.info(f'Starting granian (main PID: {self.pid})')
@@ -559,13 +568,7 @@ class Granian:
                 self.main_loop_interrupt.clear()
                 self._respawn_workers(workers, sock, spawn_target, target_loader)
 
-            if self.reload_signal:
-                logger.info('HUP signal received, gracefully respawning workers..')
-                workers = list(range(self.workers))
-                self.reload_signal = False
-                self.respawned_procs.clear()
-                self.main_loop_interrupt.clear()
-                self._respawn_workers(workers, sock, spawn_target, target_loader, delay=self.respawn_interval)
+            self._reload(sock, spawn_target, target_loader)
 
     def _serve(self, spawn_target, target_loader):
         sock = self.startup(spawn_target, target_loader)
@@ -580,15 +583,22 @@ class Granian:
         reload_path = Path.cwd()
         sock = self.startup(spawn_target, target_loader)
 
-        try:
-            for changes in watchfiles.watch(reload_path, stop_event=self.main_loop_interrupt):
-                logger.info('Changes detected, reloading workers..')
-                for change, file in changes:
-                    logger.info(f'{change.raw_str().capitalize()}: {file}')
-                self._stop_workers()
-                self._spawn_workers(sock, spawn_target, target_loader)
-        except StopIteration:
-            pass
+        while True:
+            try:
+                for changes in watchfiles.watch(reload_path, stop_event=self.main_loop_interrupt):
+                    logger.info('Changes detected, reloading workers..')
+                    for change, file in changes:
+                        logger.info(f'{change.raw_str().capitalize()}: {file}')
+                    self._stop_workers()
+                    self._spawn_workers(sock, spawn_target, target_loader)
+            except StopIteration:
+                pass
+
+            if self.interrupt_signal:
+                break
+
+            if self.reload_signal:
+                self._reload(sock, spawn_target, target_loader)
 
         self.shutdown()
 


### PR DESCRIPTION
Fixes an issue with the reload option: Missing reload handling causes granian with `reload=True` to shutdown instead of respawning workers.