### PR TITLE
On reload, ignore non python files by default

### DIFF
--- a/granian/server.py
+++ b/granian/server.py
@@ -643,7 +643,7 @@ class Granian:
             reload_filter = watchfiles.filters.DefaultFilter(
                 ignore_dirs=ignore_dirs,
                 ignore_entity_patterns=ignore_entity_patterns,
-                ignore_paths=ignore_paths
+                ignore_paths=ignore_paths,
             )
         else:
             # Use given or python filter rules
@@ -651,9 +651,7 @@ class Granian:
             # Extend `reload_filter` with explicit args
             ignore_paths = (*reload_filter.ignore_paths, *self.reload_ignore_paths)
             # Construct new filter
-            reload_filter = watchfiles.filters.PythonFilter(
-                ignore_paths=ignore_paths
-            )
+            reload_filter = watchfiles.filters.PythonFilter(ignore_paths=ignore_paths)
 
         sock = self.startup(spawn_target, target_loader)
 

--- a/granian/server.py
+++ b/granian/server.py
@@ -629,19 +629,31 @@ class Granian:
             logger.error('Using --reload requires the granian[reload] extra')
             sys.exit(1)
 
-        # Use given or default filter rules
-        reload_filter = self.reload_filter or watchfiles.filters.DefaultFilter
-        # Extend `reload_filter` with explicit args
-        ignore_dirs = (*reload_filter.ignore_dirs, *self.reload_ignore_dirs)
-        ignore_entity_patterns = (
-            *reload_filter.ignore_entity_patterns,
-            *self.reload_ignore_patterns,
-        )
-        ignore_paths = (*reload_filter.ignore_paths, *self.reload_ignore_paths)
-        # Construct new filter
-        reload_filter = watchfiles.filters.DefaultFilter(
-            ignore_dirs=ignore_dirs, ignore_entity_patterns=ignore_entity_patterns, ignore_paths=ignore_paths
-        )
+        if self.reload_ignore_dirs or self.reload_ignore_patterns:
+            # Use given or default filter rules
+            reload_filter = self.reload_filter or watchfiles.filters.DefaultFilter
+            # Extend `reload_filter` with explicit args
+            ignore_dirs = (*reload_filter.ignore_dirs, *self.reload_ignore_dirs)
+            ignore_entity_patterns = (
+                *reload_filter.ignore_entity_patterns,
+                *self.reload_ignore_patterns,
+            )
+            ignore_paths = (*reload_filter.ignore_paths, *self.reload_ignore_paths)
+            # Construct new filter
+            reload_filter = watchfiles.filters.DefaultFilter(
+                ignore_dirs=ignore_dirs,
+                ignore_entity_patterns=ignore_entity_patterns,
+                ignore_paths=ignore_paths
+            )
+        else:
+            # Use given or python filter rules
+            reload_filter = self.reload_filter or watchfiles.filters.PythonFilter
+            # Extend `reload_filter` with explicit args
+            ignore_paths = (*reload_filter.ignore_paths, *self.reload_ignore_paths)
+            # Construct new filter
+            reload_filter = watchfiles.filters.PythonFilter(
+                ignore_paths=ignore_paths
+            )
 
         sock = self.startup(spawn_target, target_loader)
 


### PR DESCRIPTION
Testing granian I realized that reload was trigger by default for all kind of files. This is a bit annoying for development if you are just changing the html templates and I think it only needs to reload for Python files.

To do not break the previous behaviour (completely), now the reload only use `DefaultFilter` if params required to build that filter are set.

Happy to add some tests but I couldn't find any similar or related test to guide me in the process.

BTW, from my point of view, reload only on Python files always should be the enough, I don't know if the usage of `DefaultFilter` is a bug or a desired behaviour.

One more think, I couldn't do this without #119 it's my first time working with maturing :)