### PR TITLE
feat: add support for logging.NOTSET level

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Options:
                                   409600]
   --log / --no-log                Enable logging  [env var:
                                   GRANIAN_LOG_ENABLED; default: (enabled)]
-  --log-level [critical|error|warning|warn|info|debug]
+  --log-level [critical|error|warning|warn|info|debug|notset]
                                   Log level  [env var: GRANIAN_LOG_LEVEL;
                                   default: (info)]
   --log-config FILE               Logging configuration file (json)  [env var:

--- a/granian/log.py
+++ b/granian/log.py
@@ -14,6 +14,7 @@ class LogLevels(str, Enum):
     warn = 'warn'
     info = 'info'
     debug = 'debug'
+    notset = 'notset'
 
 
 log_levels_map = {
@@ -23,6 +24,7 @@ log_levels_map = {
     LogLevels.warn: logging.WARN,
     LogLevels.info: logging.INFO,
     LogLevels.debug: logging.DEBUG,
+    LogLevels.notset: logging.NOTSET,
 }
 
 LOGGING_CONFIG = {


### PR DESCRIPTION
From Python docs: 

logging.NOTSET: When set on a logger, indicates that ancestor loggers are to be consulted to determine the effective level. If that still resolves to NOTSET, then all events are logged.