### PR TITLE
Fix drops in `PyFutureAwaitable` at wrong state path

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -390,7 +390,10 @@ impl PyFutureAwaitable {
             )
             .is_err()
         {
-            Python::with_gil(|_| drop(result));
+            Python::with_gil(|_| {
+                drop(result);
+                drop(pyself);
+            });
             return;
         }
 


### PR DESCRIPTION
Close #469 