### PR TITLE
Possible fix for handling invalid http paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,13 +117,3 @@ asyncio_mode = 'auto'
 
 [tool.uv]
 package = false
-
-[dependency-groups]
-dev = [
-    "httpx>=0.25.2",
-    "maturin>=1.8.1",
-    "pip>=25.0",
-    "pytest>=7.4.4",
-    "pytest-asyncio>=0.21.2",
-    "websockets>=11.0.3",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,3 +117,13 @@ asyncio_mode = 'auto'
 
 [tool.uv]
 package = false
+
+[dependency-groups]
+dev = [
+    "httpx>=0.25.2",
+    "maturin>=1.8.1",
+    "pip>=25.0",
+    "pytest>=7.4.4",
+    "pytest-asyncio>=0.21.2",
+    "websockets>=11.0.3",
+]

--- a/src/asgi/utils.rs
+++ b/src/asgi/utils.rs
@@ -17,7 +17,9 @@ macro_rules! scope_native_parts {
             .uri
             .path_and_query()
             .map_or_else(|| ("", ""), |pq| (pq.path(), pq.query().unwrap_or("")));
-        let $path = percent_encoding::percent_decode_str(path_raw).decode_utf8().unwrap();
+        let $path = percent_encoding::percent_decode_str(path_raw)
+            .decode_utf8()
+            .unwrap_or("".into());
         let $version = match $req.version {
             hyper::Version::HTTP_10 => "1",
             hyper::Version::HTTP_11 => "1.1",

--- a/src/asgi/utils.rs
+++ b/src/asgi/utils.rs
@@ -17,9 +17,7 @@ macro_rules! scope_native_parts {
             .uri
             .path_and_query()
             .map_or_else(|| ("", ""), |pq| (pq.path(), pq.query().unwrap_or("")));
-        let $path = percent_encoding::percent_decode_str(path_raw)
-            .decode_utf8()
-            .unwrap_or("".into());
+        let $path = percent_encoding::percent_decode_str(path_raw).decode_utf8_lossy();
         let $version = match $req.version {
             hyper::Version::HTTP_10 => "1",
             hyper::Version::HTTP_11 => "1.1",

--- a/src/rsgi/types.rs
+++ b/src/rsgi/types.rs
@@ -184,8 +184,8 @@ macro_rules! rsgi_scope_cls {
             }
 
             #[getter(path)]
-            fn get_path(&self) -> Result<Cow<str>> {
-                Ok(percent_decode_str(self.uri.path()).decode_utf8()?)
+            fn get_path(&self) -> Cow<str> {
+                percent_decode_str(self.uri.path()).decode_utf8_lossy()
             }
 
             #[getter(query_string)]

--- a/tests/apps/asgi.py
+++ b/tests/apps/asgi.py
@@ -10,11 +10,6 @@ PLAINTEXT_RESPONSE = {
     'status': 200,
     'headers': [[b'content-type', b'text/plain; charset=utf-8']],
 }
-NOT_FOUND_RESPONSE = {
-    'type': 'http.response.start',
-    'status': 404,
-    'headers': [[b'content-type', b'text/plain; charset=utf-8']],
-}
 JSON_RESPONSE = {'type': 'http.response.start', 'status': 200, 'headers': [[b'content-type', b'application/json']]}
 MEDIA_RESPONSE = {
     'type': 'http.response.start',
@@ -163,13 +158,11 @@ async def lifespan(scope, receive, send):
         scope['state']['global'] = 'test'
         await send({'type': 'lifespan.startup.complete'})
 
-async def not_found(scope, receive, send):
-    await send(NOT_FOUND_RESPONSE)
 
 def app(scope, receive, send):
     if scope['type'] == 'lifespan':
         return lifespan(scope, receive, send)
-    paths = {
+    return {
         '/info': info,
         '/sniffio': sniff_aio_impl,
         '/echo': echo,
@@ -182,7 +175,4 @@ def app(scope, receive, send):
         '/err_proto': err_proto,
         '/timeout_n': timeout_n,
         '/timeout_w': timeout_w
-        }
-    if scope['path'] not in paths:
-        return not_found(scope,receive, send)
-    return paths[scope['path']](scope, receive, send) 
+    }.get(scope['path'], info)(scope, receive, send)

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -112,4 +112,4 @@ async def test_timeout(asgi_server, threading_mode):
 async def test_protocol_error(asgi_server, threading_mode):
     async with asgi_server(threading_mode) as port:
         res = httpx.get(f'http://localhost:{port}/%c0')
-    assert res.status_code == 404
+    assert res.status_code == 500

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -105,3 +105,11 @@ async def test_timeout(asgi_server, threading_mode):
 
     assert res.status_code == 200
     assert res.text == 'timeout'
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(bool(os.getenv('PGO_RUN')), reason='PGO build')
+@pytest.mark.parametrize('threading_mode', ['runtime', 'workers'])
+async def test_protocol_error(asgi_server, threading_mode):
+    async with asgi_server(threading_mode) as port:
+        res = httpx.get(f'http://localhost:{port}/%c0')
+    assert res.status_code == 404

--- a/tests/test_asgi.py
+++ b/tests/test_asgi.py
@@ -28,6 +28,18 @@ async def test_scope(asgi_server, threading_mode):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(bool(os.getenv('PGO_RUN')), reason='PGO build')
+@pytest.mark.parametrize('threading_mode', ['runtime', 'workers'])
+async def test_scope_path_utf8_lossy(asgi_server, threading_mode):
+    async with asgi_server(threading_mode) as port:
+        res = httpx.get(f'http://localhost:{port}/%c0')
+
+    assert res.status_code == 200
+    data = res.json()
+    assert data['path'] == '/\ufffd'
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize('threading_mode', ['runtime', 'workers'])
 async def test_body(asgi_server, threading_mode):
     async with asgi_server(threading_mode) as port:
@@ -105,11 +117,3 @@ async def test_timeout(asgi_server, threading_mode):
 
     assert res.status_code == 200
     assert res.text == 'timeout'
-
-@pytest.mark.asyncio
-@pytest.mark.skipif(bool(os.getenv('PGO_RUN')), reason='PGO build')
-@pytest.mark.parametrize('threading_mode', ['runtime', 'workers'])
-async def test_protocol_error(asgi_server, threading_mode):
-    async with asgi_server(threading_mode) as port:
-        res = httpx.get(f'http://localhost:{port}/%c0')
-    assert res.status_code == 500


### PR DESCRIPTION
Hello! This is an incomplete attempt at trying to fix the bug that we encountered. I was unable to `cargo build` the project as I'm not familiar with py03. 

What I *think* is happening is that when the path is parsed the `percent_decode` function, it returns a Result type and granian is currently `unwrapping` the result, causing the error to cause the the process to crash. 

If instead of unwrapping it, we return `unwrap_or` with a `Cow<_, str>` with an empty value that should fix it (which is what I've done). Although I suspect this may not be the best way to approach it as there may be other instances of path parsing where we need to decode valid UTF8 but return either an empty string or some HTTP client error? 

Issue: https://github.com/emmett-framework/granian/issues/490