### PR TITLE
⬆️ Allow watchfiles>1.0 in reload extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ pname = [
     'setproctitle~=1.3.3',
 ]
 reload = [
-    'watchfiles~=0.21',
+    'watchfiles>=0.21,<2',
 ]
 lint = [
     'ruff~=0.5.0',


### PR DESCRIPTION
The major release of watchfiles (1.0) should not break anything in granian (main breaking change is the drop of Python 3.8). I'm not sure how I can test it though...