### PR TITLE
do not kill main process on worker exit on hot reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,10 +255,6 @@ Options:
                                   Extends the default list of directories to
                                   ignore in watchfiles' default filter  [env
                                   var: GRANIAN_RELOAD_IGNORE_DIRS]
-  --reload-ignore-worker-failure / --no-reload-ignore-worker-failure
-                                  Ignore worker failures when auto reload is
-                                  enabled [env var: GRANIAN_RELOAD_IGNORE_WORK
-                                  ER_FAILURE; default: (disabled)]
   --reload-ignore-patterns TEXT   File/directory name patterns (regex) to
                                   ignore changes for. Extends the default list
                                   of patterns to ignore in watchfiles' default
@@ -266,6 +262,11 @@ Options:
                                   GRANIAN_RELOAD_IGNORE_PATTERNS]
   --reload-ignore-paths PATH      Absolute paths to ignore changes for  [env
                                   var: GRANIAN_RELOAD_IGNORE_PATHS]
+  --reload-ignore-worker-failure / --no-reload-ignore-worker-failure
+                                  Ignore worker failures when auto reload is
+                                  enabled  [env var:
+                                  GRANIAN_RELOAD_IGNORE_WORKER_FAILURE;
+                                  default: (disabled)]
   --process-name TEXT             Set a custom name for processes (requires
                                   granian[pname] extra)  [env var:
                                   GRANIAN_PROCESS_NAME]

--- a/README.md
+++ b/README.md
@@ -255,6 +255,10 @@ Options:
                                   Extends the default list of directories to
                                   ignore in watchfiles' default filter  [env
                                   var: GRANIAN_RELOAD_IGNORE_DIRS]
+  --reload-ignore-worker-failure / --no-reload-ignore-worker-failure
+                                  Ignore worker failures when auto reload is
+                                  enabled [env var: GRANIAN_RELOAD_IGNORE_WORK
+                                  ER_FAILURE; default: (disabled)]
   --reload-ignore-patterns TEXT   File/directory name patterns (regex) to
                                   ignore changes for. Extends the default list
                                   of patterns to ignore in watchfiles' default

--- a/granian/cli.py
+++ b/granian/cli.py
@@ -263,6 +263,11 @@ def option(*param_decls: str, cls: Optional[Type[click.Option]] = None, **attrs:
     multiple=True,
 )
 @option(
+    '--reload-ignore-worker-failure/--no-reload-ignore-worker-failure',
+    default=False,
+    help='Ignore worker failures when auto reload is enabled',
+)
+@option(
     '--process-name',
     help='Set a custom name for processes (requires granian[pname] extra)',
 )
@@ -321,6 +326,7 @@ def cli(
     reload_ignore_dirs: Optional[List[str]],
     reload_ignore_patterns: Optional[List[str]],
     reload_ignore_paths: Optional[List[pathlib.Path]],
+    reload_ignore_worker_failure: bool,
     process_name: Optional[str],
     pid_file: Optional[pathlib.Path],
 ) -> None:
@@ -386,6 +392,7 @@ def cli(
         reload_ignore_paths=reload_ignore_paths,
         reload_ignore_dirs=reload_ignore_dirs,
         reload_ignore_patterns=reload_ignore_patterns,
+        reload_ignore_worker_failure=reload_ignore_worker_failure,
         process_name=process_name,
         pid_file=pid_file,
     )

--- a/granian/server/common.py
+++ b/granian/server/common.py
@@ -45,9 +45,10 @@ class AbstractWorker:
         self.inner.join()
         if not self.interrupt_by_parent:
             logger.error(f'Unexpected exit from worker-{self.idx + 1}')
+            if self.parent.reload_on_changes and self.parent.reload_ignore_worker_failure:
+                return
             self.parent.interrupt_children.append(self.idx)
-            if not self.parent.reload_on_changes and not self.parent.reload_ignore_worker_failure:
-                self.parent.main_loop_interrupt.set()
+            self.parent.main_loop_interrupt.set()
 
     def _watch(self):
         watcher = threading.Thread(target=self._watcher)

--- a/granian/server/common.py
+++ b/granian/server/common.py
@@ -46,7 +46,8 @@ class AbstractWorker:
         if not self.interrupt_by_parent:
             logger.error(f'Unexpected exit from worker-{self.idx + 1}')
             self.parent.interrupt_children.append(self.idx)
-            self.parent.main_loop_interrupt.set()
+            if not self.parent.reload_on_changes:
+                self.parent.main_loop_interrupt.set()
 
     def _watch(self):
         watcher = threading.Thread(target=self._watcher)

--- a/granian/server/common.py
+++ b/granian/server/common.py
@@ -46,7 +46,7 @@ class AbstractWorker:
         if not self.interrupt_by_parent:
             logger.error(f'Unexpected exit from worker-{self.idx + 1}')
             self.parent.interrupt_children.append(self.idx)
-            if not self.parent.reload_on_changes:
+            if not self.parent.reload_on_changes and not self.parent.reload_ignore_worker_failure:
                 self.parent.main_loop_interrupt.set()
 
     def _watch(self):
@@ -112,6 +112,7 @@ class AbstractServer(Generic[WT]):
         reload_ignore_patterns: Optional[Sequence[str]] = None,
         reload_ignore_paths: Optional[Sequence[Path]] = None,
         reload_filter: Optional[Type[watchfiles.BaseFilter]] = None,
+        reload_ignore_worker_failure: bool = False,
         process_name: Optional[str] = None,
         pid_file: Optional[Path] = None,
     ):
@@ -154,6 +155,7 @@ class AbstractServer(Generic[WT]):
         self.reload_ignore_dirs = reload_ignore_dirs or ()
         self.reload_ignore_patterns = reload_ignore_patterns or ()
         self.reload_filter = reload_filter
+        self.reload_ignore_worker_failure = reload_ignore_worker_failure
         self.process_name = process_name
         self.pid_file = pid_file
 


### PR DESCRIPTION
if the worker exits on hot reload, most likely the we don't want the main thread to be interrupted