### PR TITLE
Fix the re.split deprecation warning

### DIFF
--- a/granian/_internal.py
+++ b/granian/_internal.py
@@ -7,7 +7,7 @@ from typing import Callable, List, Optional
 
 
 def get_import_components(path: str) -> List[Optional[str]]:
-    return (re.split(r':(?![\\/])', path, 1) + [None])[:2]
+    return (re.split(r':(?![\\/])', path, maxsplit=1) + [None])[:2]
 
 
 def prepare_import(path: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,6 @@ extend-select = [
 extend-ignore = [
     'B008', # function calls in args defaults are fine
     'B009', # getattr with constants is fine
-    'B034', # re.split won't confuse us
     'B904', # rising without from is fine
     'E501', # leave line length to black
     'N818', # leave to us exceptions naming


### PR DESCRIPTION
The B034 linting rule already silenced the check for using `re.split` with positional arguments. Python 3.13 deprecated passing `maxsplit` as a positional parameter, giving us a better reason to change it than pure stylistic preferences.