### PR TITLE
Add human-readable CLI duration arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ Options:
   --blocking-threads INTEGER RANGE
                                   Number of blocking threads (per worker)
                                   [env var: GRANIAN_BLOCKING_THREADS; x>=1]
-  --blocking-threads-idle-timeout INTEGER RANGE
-                                  The maximum amount of time in seconds an
-                                  idle blocking thread will be kept alive
-                                  [env var:
+  --blocking-threads-idle-timeout DURATION
+                                  The maximum amount of time in seconds (or a
+                                  human-readable duration) an idle blocking
+                                  thread will be kept alive  [env var:
                                   GRANIAN_BLOCKING_THREADS_IDLE_TIMEOUT;
                                   default: 30; 10<=x<=600]
   --runtime-threads INTEGER RANGE
@@ -221,8 +221,9 @@ Options:
                                   connection alive  [env var:
                                   GRANIAN_HTTP2_KEEP_ALIVE_INTERVAL;
                                   1<=x<=60000]
-  --http2-keep-alive-timeout INTEGER RANGE
-                                  Sets a timeout (in seconds) for receiving an
+  --http2-keep-alive-timeout DURATION
+                                  Sets a timeout (in seconds or a human-
+                                  readable duration) for receiving an
                                   acknowledgement of the HTTP2 keep-alive ping
                                   [env var: GRANIAN_HTTP2_KEEP_ALIVE_TIMEOUT;
                                   default: 20; x>=1]
@@ -280,13 +281,13 @@ Options:
   --workers-lifetime DURATION     The maximum amount of time in seconds (or a
                                   human-readable duration) a worker will be
                                   kept alive before respawn  [env var:
-                                  GRANIAN_WORKERS_LIFETIME]
+                                  GRANIAN_WORKERS_LIFETIME; x>=60]
   --workers-kill-timeout DURATION
                                   The amount of time in seconds (or a human-
                                   readable duration) to wait for killing
                                   workers that refused to gracefully stop
                                   [env var: GRANIAN_WORKERS_KILL_TIMEOUT;
-                                  default: (disabled)]
+                                  default: (disabled); 1<=x<=1800]
   --factory / --no-factory        Treat target as a factory function, that
                                   should be invoked to build the actual target
                                   [env var: GRANIAN_FACTORY; default:
@@ -304,7 +305,8 @@ Options:
   --static-path-expires DURATION  Cache headers expiration (in seconds or a
                                   human-readable duration) for static file
                                   serving  [env var:
-                                  GRANIAN_STATIC_PATH_EXPIRES; default: 86400]
+                                  GRANIAN_STATIC_PATH_EXPIRES; default: 86400;
+                                  x>=60]
   --reload / --no-reload          Enable auto reload on application's files
                                   changes (requires granian[reload] extra)
                                   [env var: GRANIAN_RELOAD; default:

--- a/README.md
+++ b/README.md
@@ -277,16 +277,16 @@ Options:
   --respawn-interval FLOAT        The number of seconds to sleep between
                                   workers respawn  [env var:
                                   GRANIAN_RESPAWN_INTERVAL; default: 3.5]
-  --workers-lifetime INTEGER RANGE
-                                  The maximum amount of time in seconds a
-                                  worker will be kept alive before respawn
-                                  [env var: GRANIAN_WORKERS_LIFETIME; x>=60]
-  --workers-kill-timeout INTEGER RANGE
-                                  The amount of time in seconds to wait for
-                                  killing workers that refused to gracefully
-                                  stop  [env var:
-                                  GRANIAN_WORKERS_KILL_TIMEOUT; default:
-                                  (disabled); 1<=x<=1800]
+  --workers-lifetime DURATION     The maximum amount of time in seconds (or a
+                                  human-readable duration) a worker will be
+                                  kept alive before respawn  [env var:
+                                  GRANIAN_WORKERS_LIFETIME]
+  --workers-kill-timeout DURATION
+                                  The amount of time in seconds (or a human-
+                                  readable duration) to wait for killing
+                                  workers that refused to gracefully stop
+                                  [env var: GRANIAN_WORKERS_KILL_TIMEOUT;
+                                  default: (disabled)]
   --factory / --no-factory        Treat target as a factory function, that
                                   should be invoked to build the actual target
                                   [env var: GRANIAN_FACTORY; default:
@@ -301,11 +301,10 @@ Options:
                                   (/static)]
   --static-path-mount DIRECTORY   Path to mount for static file serving  [env
                                   var: GRANIAN_STATIC_PATH_MOUNT]
-  --static-path-expires INTEGER RANGE
-                                  Cache headers expiration (in seconds) for
-                                  static file serving  [env var:
-                                  GRANIAN_STATIC_PATH_EXPIRES; default: 86400;
-                                  x>=60]
+  --static-path-expires DURATION  Cache headers expiration (in seconds or a
+                                  human-readable duration) for static file
+                                  serving  [env var:
+                                  GRANIAN_STATIC_PATH_EXPIRES; default: 86400]
   --reload / --no-reload          Enable auto reload on application's files
                                   changes (requires granian[reload] extra)
                                   [env var: GRANIAN_RELOAD; default:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,49 @@
+import click
+import pytest
+
+from granian.cli import Duration
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected'),
+    (
+        ('10', 10),
+        ('10s', 10),
+        ('10m', 60 * 10),
+        ('10m10s', 60 * 10 + 10),
+        ('10h', 60 * 60 * 10),
+        ('10d', 24 * 60 * 60 * 10),
+        ('10d10h10m10s', 24 * 60 * 60 * 10 + 60 * 60 * 10 + 60 * 10 + 10),
+    ),
+)
+def test_duration_convert(value: str, expected: int) -> None:
+    duration_type = Duration()
+    assert duration_type.convert(value, None, None) == expected
+
+
+@pytest.mark.parametrize(
+    ('value', 'error_message'),
+    (
+        ('10x', r"'10x' is not a valid duration"),
+        ('10d10h10m10s10', r"'10d10h10m10s10' is not a valid duration"),
+        ('10d10h10m10s10', r"'10d10h10m10s10' is not a valid duration"),
+    ),
+)
+def test_duration_convert_invalid(value: str, error_message: str) -> None:
+    duration_type = Duration()
+    with pytest.raises(click.BadParameter, match=error_message):
+        duration_type.convert(value, None, None)
+
+
+@pytest.mark.parametrize(
+    ('value', 'error_message'),
+    (
+        ('1000', r"'1000' is greater than the maximum allowed value of 100 seconds"),
+        ('30m', r"'30m' is greater than the maximum allowed value of 100 seconds"),
+        ('5', r"'5' is less than the minimum allowed value of 10 seconds"),
+    ),
+)
+def test_duration_convert_out_of_range(value: str, error_message: str) -> None:
+    duration_type = Duration(min_seconds=10, max_seconds=100)
+    with pytest.raises(click.BadParameter, match=error_message):
+        duration_type.convert(value, None, None)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,6 +44,6 @@ def test_duration_convert_invalid(value: str, error_message: str) -> None:
     ),
 )
 def test_duration_convert_out_of_range(value: str, error_message: str) -> None:
-    duration_type = Duration(min_seconds=10, max_seconds=100)
+    duration_type = Duration(10, 100)
     with pytest.raises(click.BadParameter, match=error_message):
         duration_type.convert(value, None, None)


### PR DESCRIPTION
closes #621

I have added a `Duration` parameter that accepts human-readable durations such as `24h`, `6m`, `2s`, or a combination such as  `1m30s`. The default behaviour remains unchanged, so `60` for example will be treated as 60 seconds.

I have changed some of the CLI parameters to be of `Duration` type.
- `--blocking-threads-idle-timeout`
- `--http2-keep-alive-timeout`
- `--workers-lifetime`
- `--workers-kill-timeout`
- `--static-path-expires`
