### PR TITLE
Re-add full strip on release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,4 +71,13 @@ incremental = false
 lto = "fat"
 opt-level = 3
 panic = "abort"
+strip = true
+
+[profile.unstripped]
+inherits = "release"
 strip = "debuginfo"
+
+[profile.profiling]
+inherits = "release"
+debug = true
+strip = false


### PR DESCRIPTION
This reverts https://github.com/emmett-framework/granian/commit/288a96f6768547d64ccff92f909159ffece042b1 (introduced to address #505) and adds `unstripped` and `profiling` release profiles.

This is mainly due to the *situation* with https://github.com/pypi/support/issues/6576 – which is still unsolved after several weeks – and trying to reduce the overall release size.
People interested in having debug symbols should build Granian from source with the relevant profile in the meantime.