### PR TITLE
Add support for trailers extension

### DIFF
--- a/src/asgi/types.rs
+++ b/src/asgi/types.rs
@@ -2,8 +2,9 @@ use hyper::{HeaderMap, body};
 use tokio_tungstenite::tungstenite::{Message, protocol::CloseFrame};
 
 pub(crate) enum ASGIMessageType {
-    HTTPResponseStart((u16, HeaderMap)),
+    HTTPResponseStart((u16, HeaderMap, bool)),
     HTTPResponseBody((Box<[u8]>, bool)),
+    HTTPResponseTrailers((HeaderMap, bool)),
     HTTPResponseFile(String),
     HTTPDisconnect,
     HTTPRequestBody((body::Bytes, bool)),

--- a/src/asgi/utils.rs
+++ b/src/asgi/utils.rs
@@ -47,6 +47,7 @@ macro_rules! build_scope_common {
                 .get_or_try_init($py, || {
                     let rv = PyDict::new($py);
                     rv.set_item("http.response.pathsend", PyDict::new($py))?;
+                    rv.set_item("http.response.trailers", PyDict::new($py))?;
                     Ok::<PyObject, PyErr>(rv.into())
                 })?
                 .bind($py)


### PR DESCRIPTION
For #93 

I am interested in trying to implement the gRPC protocol, which uses trailers, using ASGI and granian. I noticed there is an issue for it so tried implementing support. Note that I'm not a Rust dev so the code might be quite unidiomatic.

More problematically, because there aren't any Python HTTP clients that support trailers, I'm not sure what a good way to add tests for the new feature is, currently I've just verified with `curl -v --http2-prior-knowledge -H "TE: trailers" http://localhost:8000/trailers`. Appreciate any advice on how we could deal with that. Or if things are too immature regarding trailers in the ecosystem, happy to close for now