### PR TITLE
Define __all__ for package init

### DIFF
--- a/granian/__init__.py
+++ b/granian/__init__.py
@@ -1,3 +1,5 @@
-from ._granian import __version__  # noqa: F401
-from ._loops import loops  # noqa: F401
-from .server import Server as Granian  # noqa: F401
+__all__ = ['__version__', 'loops', 'Granian']
+
+from ._granian import __version__
+from ._loops import loops
+from .server import Server as Granian

--- a/granian/__init__.py
+++ b/granian/__init__.py
@@ -1,5 +1,6 @@
-__all__ = ['__version__', 'loops', 'Granian']
-
 from ._granian import __version__
 from ._loops import loops
 from .server import Server as Granian
+
+
+__all__ = ['__version__', 'loops', 'Granian']


### PR DESCRIPTION
I noticed type checkers have trouble with the `granian` package, and it seems to be because of the lack of a `__all__` explicitly defining the exports. We see this is effective as the lint ignores can go away too.