### PR TITLE
Use monotonic time and perf_counter

### DIFF
--- a/benchmarks/ws/benchmark.py
+++ b/benchmarks/ws/benchmark.py
@@ -26,21 +26,21 @@ def _client_redy(target):
 
 
 async def _client_recv(ws, to_recv):
-    t_start = time.time()
+    t_start = time.perf_counter()
     recv = 0
     while recv < to_recv:
         await ws.recv()
         recv += 1
-    return (recv, time.time() - t_start)
+    return (recv, time.perf_counter() - t_start)
 
 
 async def _client_send(ws, messages):
-    t_start = time.time()
+    t_start = time.perf_counter()
     sent = 0
     for message in messages:
         await ws.send(message)
         sent += 1
-    return (sent, time.time() - t_start)
+    return (sent, time.perf_counter() - t_start)
 
 
 async def client(idx, messages, ready_signal):
@@ -55,9 +55,9 @@ async def client(idx, messages, ready_signal):
             asyncio.create_task(_client_recv(ws, len(messages) * CONCURRENCY)),
             asyncio.create_task(_client_send(ws, messages)),
         )
-        t_start = time.time()
+        t_start = time.perf_counter()
         recv_data, send_data = await asyncio.gather(_task_recv, _task_send)
-        t_end = time.time() - t_start
+        t_end = time.perf_counter() - t_start
     # print(f'Client {idx} terminated')
     return (recv_data, send_data, t_end)
 

--- a/granian/asgi.py
+++ b/granian/asgi.py
@@ -113,7 +113,7 @@ def _callback_wrapper(callback, scope_opts, state, access_log_fmt=None):
         return callback(scope, proto.receive, proto.send)
 
     async def _http_logger(scope, proto):
-        t = time.time()
+        t = time.perf_counter()
         try:
             rv = await _runner(scope, proto)
         finally:
@@ -121,7 +121,7 @@ def _callback_wrapper(callback, scope_opts, state, access_log_fmt=None):
         return rv
 
     def _ws_logger(scope, proto):
-        access_log(time.time(), scope, 101)
+        access_log(time.perf_counter(), scope, 101)
         return _runner(scope, proto)
 
     def _logger(scope, proto):

--- a/granian/log.py
+++ b/granian/log.py
@@ -78,7 +78,7 @@ def log_request_builder(fmt):
     local_tz = local_now.tzinfo
 
     def log_request(rtime, req, res_code):
-        dt = time.time() - rtime
+        dt = time.perf_counter() - rtime
         rdt = datetime.datetime.fromtimestamp(rtime, tz=local_tz)
         access_logger.info(
             fmt,

--- a/granian/rsgi.py
+++ b/granian/rsgi.py
@@ -88,7 +88,7 @@ def _callbacks_from_target(target):
 
 def _callback_wrapper(callback, access_log_fmt=False):
     async def _http_logger(scope, proto):
-        t = time.time()
+        t = time.perf_counter()
         try:
             rv = await callback(scope, proto)
         finally:
@@ -96,7 +96,7 @@ def _callback_wrapper(callback, access_log_fmt=False):
         return rv
 
     def _ws_logger(scope, proto):
-        access_log(time.time(), scope, 101)
+        access_log(time.perf_counter(), scope, 101)
         return callback(scope, proto)
 
     def _logger(scope, proto):

--- a/granian/server/common.py
+++ b/granian/server/common.py
@@ -37,7 +37,7 @@ class AbstractWorker:
         self.parent = parent
         self.idx = idx
         self.interrupt_by_parent = False
-        self.birth = time.time()
+        self.birth = time.monotonic()
         self._spawn(target, args)
 
     def _spawn(self, target, args):
@@ -293,7 +293,7 @@ class AbstractServer(Generic[WT]):
 
     def _respawn_workers(self, workers, spawn_target, target_loader, delay: float = 0):
         for idx in workers:
-            self.respawned_wrks[idx] = time.time()
+            self.respawned_wrks[idx] = time.monotonic()
             logger.info(f'Respawning worker-{idx + 1}')
             old_wrk = self.wrks.pop(idx)
             wrk = self._spawn_worker(idx=idx, target=spawn_target, callback_loader=target_loader)
@@ -448,7 +448,7 @@ class AbstractServer(Generic[WT]):
                 if not self.respawn_failed_workers:
                     break
 
-                cycle = time.time()
+                cycle = time.monotonic()
                 if any(cycle - self.respawned_wrks.get(idx, 0) <= 5.5 for idx in self.interrupt_children):
                     logger.error('Worker crash loop detected, exiting')
                     break
@@ -468,7 +468,7 @@ class AbstractServer(Generic[WT]):
                 if self.lifetime_signal:
                     self.lifetime_signal = False
                     ttl = self.workers_lifetime * 0.95
-                    now = time.time()
+                    now = time.monotonic()
                     etas = [self.workers_lifetime]
                     for worker in list(self.wrks):
                         if (now - worker.birth) >= ttl:

--- a/granian/server/embed.py
+++ b/granian/server/embed.py
@@ -337,7 +337,7 @@ class Server(AbstractServer[AsyncWorker]):
 
     async def _respawn_workers(self, workers, spawn_target, target_loader, delay: float = 0):
         for idx in workers:
-            self.respawned_wrks[idx] = time.time()
+            self.respawned_wrks[idx] = time.monotonic()
             logger.info(f'Respawning worker-{idx + 1}')
             old_wrk = self.wrks.pop(idx)
             wrk = self._spawn_worker(idx=idx, target=spawn_target, callback_loader=target_loader)

--- a/granian/wsgi.py
+++ b/granian/wsgi.py
@@ -58,7 +58,7 @@ def _callback_wrapper(callback: Callable[..., Any], scope_opts: Dict[str, Any], 
         return resp.status
 
     def _logger(proto, scope):
-        t = time.time()
+        t = time.perf_counter()
         try:
             status = _runner(proto, scope)
             access_log(t, scope, status)


### PR DESCRIPTION
When using granian in a production system, we noticed an issue. In the logs, we are printing the `dt_ms` field, and it sometimes reports a clearly incorrect time, such as -15220ms. I took a look at the code and saw you're using `time.time()`. This uses the system clock and is sensitive to spontaneous clock updates outside of our control. Instead, for this use case `time.perf_counter()` should be used, which guarantees a monotonically increasing clock (see https://docs.python.org/3/library/time.html).

I took the liberty of replacing all the usages of `time.time()` with `time.perf_counter()` or `time.monotonic()` where appropriate. Note that in CPython, both `perf_counter` and `monotonic` are actually the same function, but conceptually they are defined differently, so in each case I chose the one I thought better fit at my own discretion.

Take into account that these clocks have an undefined reference point, so they are only meaningful when subtracting their values, which I believe is the only use for all the ones I have changed in this PR.

Hopefully with this change, the reported times will be more accurate.