### PR TITLE
Fix close embed have Rust Fatal error for IO Safety violation 

### DIFF
--- a/src/net.rs
+++ b/src/net.rs
@@ -4,7 +4,7 @@ use pyo3::{IntoPyObjectExt, prelude::*};
 use std::net::{IpAddr, TcpListener};
 #[cfg(unix)]
 use std::os::unix::{
-    io::{AsRawFd, FromRawFd},
+    io::{AsRawFd},
     net::UnixListener,
 };
 #[cfg(windows)]
@@ -171,13 +171,13 @@ impl SocketHolder {
 
     #[allow(clippy::unnecessary_wraps)]
     pub fn as_tcp_listener(&self) -> Result<TcpListener> {
-        let listener = unsafe { TcpListener::from_raw_fd(self.socket.as_raw_fd()) };
+        let listener =  TcpListener::from(self.socket.try_clone()?);
         Ok(listener)
     }
 
     #[allow(clippy::unnecessary_wraps)]
     pub fn as_unix_listener(&self) -> Result<UnixListener> {
-        let listener = unsafe { UnixListener::from_raw_fd(self.socket.as_raw_fd()) };
+        let listener = UnixListener::from(self.socket.try_clone()?);
         Ok(listener)
     }
 }


### PR DESCRIPTION
# Summary

This PR updates `SocketHolder::as_tcp_listener` and `SocketHolder::as_unix_listener` to use `try_clone()` instead of constructing listeners with `from_raw_fd(as_raw_fd())`.

# Motivation

Using `TcpListener::from_raw_fd(self.socket.as_raw_fd())` (or the equivalent for UnixListener) takes ownership of the same raw file descriptor that self.socket already owns.
This can lead to double-closing the same FD once both objects are dropped, causing runtime aborts such as:

`fatal runtime error: IO Safety violation: owned file descriptor already closed`

# Benefits

Memory/FD safety: each listener now owns a duplicated file descriptor, preventing double-close issues.

Eliminates unsafe: removes the need for unsafe blocks.

Minimal overhead: dup() system call cost is negligible compared to network I/O.

# Notes

This change only affects FD ownership semantics. Runtime behavior of the listeners remains the same, except that it avoids UB/crashes when objects are dropped in different orders.