### PR TITLE
Support disabling forced reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Options:
                                   readable duration) to wait for killing
                                   workers that refused to gracefully stop
                                   [env var: GRANIAN_WORKERS_KILL_TIMEOUT;
-                                  default: (disabled); 0<=x<=1800]
+                                  default: (disabled); 1<=x<=1800]
   --factory / --no-factory        Treat target as a factory function, that
                                   should be invoked to build the actual target
                                   [env var: GRANIAN_FACTORY; default:

--- a/granian/cli.py
+++ b/granian/cli.py
@@ -293,7 +293,7 @@ def option(*param_decls: str, cls: Optional[Type[click.Option]] = None, **attrs:
 )
 @option(
     '--workers-kill-timeout',
-    type=Duration(0, 1800),
+    type=Duration(1, 1800),
     help='The amount of time in seconds (or a human-readable duration) to wait for killing workers that refused to gracefully stop',
     show_default='disabled',
 )


### PR DESCRIPTION
discussions: https://github.com/emmett-framework/granian/discussions/695
The document(👇🏻) states that the default value is disabled
```md
--workers-kill-timeout DURATION
                                  The amount of time in seconds (or a human-
                                  readable duration) to wait for killing
                                  workers that refused to gracefully stop
                                  [env var: GRANIAN_WORKERS_KILL_TIMEOUT;
                                  default: (disabled); 1<=x<=1800]
```

but the code:
```python
if self.reload_on_changes and self.workers_kill_timeout is None:
      self.workers_kill_timeout = 3.5
```