### PR TITLE
Fix crash when combining workers_lifetime and reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .DS_Store
 *.pyc
 __pycache__
-uv.lock
 
 .idea/
 *.sublime-*

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,7 @@
-from unittest.mock import patch
-
 import click
 import pytest
 
-from granian import Granian
 from granian.cli import Duration
-from granian.errors import ConfigurationError
 
 
 @pytest.mark.parametrize(
@@ -51,22 +47,3 @@ def test_duration_convert_out_of_range(value: str, error_message: str) -> None:
     duration_type = Duration(10, 100)
     with pytest.raises(click.BadParameter, match=error_message):
         duration_type.convert(value, None, None)
-
-
-def test_workers_lifetime_with_reload() -> None:
-    """Test that workers_lifetime with reload=True doesn't raise TypeError.
-
-    Regression test for when workers_lifetime was set to None before the < 60 check,
-    causing a TypeError when comparing None < 60.
-    """
-    server = Granian('tests.apps.asgi:app', interface='asgi', reload=True, workers_lifetime=100)
-    with patch.object(server, '_serve_loop'), patch.object(server, '_serve_with_reloader'):
-        server.serve()
-    assert server.workers_lifetime is None
-
-
-def test_workers_lifetime_below_minimum() -> None:
-    """Test that workers_lifetime below 60 raises ConfigurationError."""
-    server = Granian('tests.apps.asgi:app', interface='asgi', workers_lifetime=30)
-    with pytest.raises(ConfigurationError):
-        server.serve()


### PR DESCRIPTION
Hey! I just migrated totem.org to use Granian from Gunicorn. It's wonderful, less memory used and more performance!

I did run into an issue that slowed me down a bit when using `--reload` with `--workers-lifetime` for the dev server though. The order of checks makes it so the server could crash under the right conditions. Just needed to switch the checks!

I tried to add tests, but needed a mock to make it work. Happy to remove them if that's not what you want.

Thanks!