### PR TITLE
feat: Add support for simultaneous TCP and UDS binding

### DIFF
--- a/granian/_granian.pyi
+++ b/granian/_granian.pyi
@@ -62,6 +62,8 @@ class ASGIWorker:
         cls,
         worker_id: int,
         sock: Any,
+        uds_sock: Any,
+        ipc: Any,
         threads: int,
         blocking_threads: int,
         py_threads: int,
@@ -71,7 +73,7 @@ class ASGIWorker:
         http1_opts: HTTP1Settings | None,
         http2_opts: HTTP2Settings | None,
         websockets_enabled: bool,
-        static_files: tuple[str, str, str | None, str | None] | None,
+        static_files: tuple[list[tuple[str, str]], str | None, str | None] | None,
         ssl_enabled: bool,
         ssl_cert: str | None,
         ssl_key: str | None,
@@ -80,6 +82,7 @@ class ASGIWorker:
         ssl_ca: str | None,
         ssl_crl: list[str],
         ssl_client_verify: bool,
+        metrics: Any,
     ) -> ASGIWorker: ...
 
 class WSGIWorker:
@@ -87,6 +90,8 @@ class WSGIWorker:
         cls,
         worker_id: int,
         sock: Any,
+        uds_sock: Any,
+        ipc: Any,
         threads: int,
         blocking_threads: int,
         py_threads: int,
@@ -95,7 +100,7 @@ class WSGIWorker:
         http_mode: str,
         http1_opts: HTTP1Settings | None,
         http2_opts: HTTP2Settings | None,
-        static_files: tuple[str, str, str | None, str | None] | None,
+        static_files: tuple[list[tuple[str, str]], str | None, str | None] | None,
         ssl_enabled: bool,
         ssl_cert: str | None,
         ssl_key: str | None,
@@ -104,6 +109,7 @@ class WSGIWorker:
         ssl_ca: str | None,
         ssl_crl: list[str],
         ssl_client_verify: bool,
+        metrics: Any,
     ) -> WSGIWorker: ...
 
 class RSGIWorker:
@@ -111,6 +117,8 @@ class RSGIWorker:
         cls,
         worker_id: int,
         sock: Any,
+        uds_sock: Any,
+        ipc: Any,
         threads: int,
         blocking_threads: int,
         py_threads: int,
@@ -120,7 +128,7 @@ class RSGIWorker:
         http1_opts: HTTP1Settings | None,
         http2_opts: HTTP2Settings | None,
         websockets_enabled: bool,
-        static_files: tuple[str, str, str | None, str | None] | None,
+        static_files: tuple[list[tuple[str, str]], str | None, str | None] | None,
         ssl_enabled: bool,
         ssl_cert: str | None,
         ssl_key: str | None,
@@ -129,6 +137,7 @@ class RSGIWorker:
         ssl_ca: str | None,
         ssl_crl: list[str],
         ssl_client_verify: bool,
+        metrics: Any,
     ) -> RSGIWorker: ...
 
 class SocketHolder:

--- a/granian/cli.py
+++ b/granian/cli.py
@@ -113,7 +113,6 @@ def option(*param_decls: str, cls: type[click.Option] | None = None, **attrs: An
 @click.argument('app', required=True)
 @option(
     '--host',
-    default='127.0.0.1',
     help='Host address to bind to',
 )
 @option('--port', type=int, default=8000, help='Port to bind to.')
@@ -434,7 +433,7 @@ def option(*param_decls: str, cls: type[click.Option] | None = None, **attrs: An
 @click.version_option(message='%(prog)s %(version)s')
 def cli(
     app: str,
-    host: str,
+    host: str | None,
     port: int,
     uds: pathlib.Path | None,
     uds_permissions: int | None,
@@ -517,6 +516,9 @@ def cli(
     from ._internal import patch_pypath
 
     patch_pypath(working_dir)
+
+    if not host and not uds:
+        host = '127.0.0.1'
 
     server = Server(
         app,

--- a/granian/server/common.py
+++ b/granian/server/common.py
@@ -27,8 +27,8 @@ from ..net import SocketSpec, UnixSocketSpec
 WT = TypeVar('WT')
 
 WORKERS_METHODS = {
-    RuntimeModes.mt: {False: 'serve_mtr', True: 'serve_mtr_uds'},
-    RuntimeModes.st: {False: 'serve_str', True: 'serve_str_uds'},
+    RuntimeModes.mt: {False: 'serve_mtr', True: 'serve_mtr_uds', 'dual': 'serve_mtr_dual'},
+    RuntimeModes.st: {False: 'serve_str', True: 'serve_str_uds', 'dual': 'serve_str_dual'},
 }
 
 
@@ -83,7 +83,7 @@ class AbstractServer(Generic[WT]):
     def __init__(
         self,
         target: str,
-        address: str = '127.0.0.1',
+        address: str | None = '127.0.0.1',
         port: int = 8000,
         uds: Path | None = None,
         uds_permissions: int | None = None,
@@ -220,6 +220,9 @@ class AbstractServer(Generic[WT]):
         self._ssp = None
         self._shd = None
         self._sfd = None
+        self._ssp_uds = None
+        self._shd_uds = None
+        self._sfd_uds = None
         self._metrics = MetricsAggregator(self.workers)
         self._metrics_exporter = MetricsExporter(self._metrics)
         self.wrks: list[WT] = []
@@ -291,7 +294,11 @@ class AbstractServer(Generic[WT]):
 
     @property
     def _bind_addr_fmt(self):
-        return f'unix:{self.bind_uds}' if self.bind_uds else f'{self.bind_addr}:{self.bind_port}'
+        if self.bind_uds and self.bind_addr:
+            return f'unix:{self.bind_uds} and {self.bind_addr}:{self.bind_port}'
+        if self.bind_uds:
+            return f'unix:{self.bind_uds}'
+        return f'{self.bind_addr}:{self.bind_port}'
 
     @staticmethod
     def _call_hooks(hooks):
@@ -312,11 +319,13 @@ class AbstractServer(Generic[WT]):
 
     def _init_shared_socket(self):
         if self.bind_uds:
-            self._ssp = UnixSocketSpec(str(self.bind_uds), self.backlog, self.uds_permissions)
-        else:
+            self._ssp_uds = UnixSocketSpec(str(self.bind_uds), self.backlog, self.uds_permissions)
+            self._shd_uds = self._ssp_uds.build()
+            self._sfd_uds = self._shd_uds.get_fd()
+        if self.bind_addr:
             self._ssp = SocketSpec(self.bind_addr, self.bind_port, self.backlog)
-        self._shd = self._ssp.build()
-        self._sfd = self._shd.get_fd()
+            self._shd = self._ssp.build()
+            self._sfd = self._shd.get_fd()
 
     def signal_handler_interrupt(self, *args, **kwargs):
         self.interrupt_signal = True

--- a/granian/server/mp.py
+++ b/granian/server/mp.py
@@ -78,17 +78,25 @@ class WorkerProcess(AbstractWorker):
             load_env(env_files)
 
             _ipc_handle = None
-            sock, _sso = sock
-            if sys.platform == 'win32':
-                sock = SocketHolder(_sso.fileno())
-            elif ipc:
+            sock_tcp, sock_uds = sock
+            _sock_tcp = _sock_uds = None
+
+            if sock_tcp[0]:
+                _sock_tcp, _sso = sock_tcp
+                if sys.platform == 'win32':
+                    _sock_tcp = SocketHolder(_sso.fileno())
+
+            if sock_uds[0]:
+                _sock_uds, _ = sock_uds
+
+            if ipc:
                 _ipc_fd = os.dup(ipc.fileno())
                 os.set_blocking(_ipc_fd, False)
                 _ipc_handle = IPCSenderHandle(_ipc_fd)
 
             loop = loops.get(loop_impl)
             callback = callback_loader()
-            return target(worker_id, callback, sock, _ipc_handle, loop, *args, **kwargs)
+            return target(worker_id, callback, _sock_tcp, _sock_uds, _ipc_handle, loop, *args, **kwargs)
 
         return wrapped
 
@@ -116,6 +124,7 @@ class MPServer(AbstractServer[WorkerProcess]):
         worker_id: int,
         callback: Any,
         sock: Any,
+        uds_sock: Any,
         ipc: Any,
         loop: Any,
         runtime_mode: RuntimeModes,
@@ -143,6 +152,7 @@ class MPServer(AbstractServer[WorkerProcess]):
         worker = ASGIWorker(
             worker_id,
             sock,
+            uds_sock,
             ipc,
             runtime_threads,
             runtime_blocking_threads,
@@ -157,7 +167,12 @@ class MPServer(AbstractServer[WorkerProcess]):
             *ssl_ctx,
             metrics,
         )
-        serve = getattr(worker, WORKERS_METHODS[runtime_mode][sock.is_uds()])
+        if sock and uds_sock:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode]['dual'])
+        elif uds_sock:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode][True])
+        else:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode][False])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
         serve(scheduler, loop, shutdown_event)
 
@@ -167,6 +182,7 @@ class MPServer(AbstractServer[WorkerProcess]):
         worker_id: int,
         callback: Any,
         sock: Any,
+        uds_sock: Any,
         ipc: Any,
         loop: Any,
         runtime_mode: RuntimeModes,
@@ -202,6 +218,7 @@ class MPServer(AbstractServer[WorkerProcess]):
         worker = ASGIWorker(
             worker_id,
             sock,
+            uds_sock,
             ipc,
             runtime_threads,
             runtime_blocking_threads,
@@ -216,7 +233,12 @@ class MPServer(AbstractServer[WorkerProcess]):
             *ssl_ctx,
             metrics,
         )
-        serve = getattr(worker, WORKERS_METHODS[runtime_mode][sock.is_uds()])
+        if sock and uds_sock:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode]['dual'])
+        elif uds_sock:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode][True])
+        else:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode][False])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
         serve(scheduler, loop, shutdown_event)
         loop.run_until_complete(lifespan_handler.shutdown())
@@ -227,6 +249,7 @@ class MPServer(AbstractServer[WorkerProcess]):
         worker_id: int,
         callback: Any,
         sock: Any,
+        uds_sock: Any,
         ipc: Any,
         loop: Any,
         runtime_mode: RuntimeModes,
@@ -256,6 +279,7 @@ class MPServer(AbstractServer[WorkerProcess]):
         worker = RSGIWorker(
             worker_id,
             sock,
+            uds_sock,
             ipc,
             runtime_threads,
             runtime_blocking_threads,
@@ -270,7 +294,12 @@ class MPServer(AbstractServer[WorkerProcess]):
             *ssl_ctx,
             metrics,
         )
-        serve = getattr(worker, WORKERS_METHODS[runtime_mode][sock.is_uds()])
+        if sock and uds_sock:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode]['dual'])
+        elif uds_sock:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode][True])
+        else:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode][False])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
         serve(scheduler, loop, shutdown_event)
         callback_del(loop)
@@ -281,6 +310,7 @@ class MPServer(AbstractServer[WorkerProcess]):
         worker_id: int,
         callback: Any,
         sock: Any,
+        uds_sock: Any,
         ipc: Any,
         loop: Any,
         runtime_mode: RuntimeModes,
@@ -308,6 +338,7 @@ class MPServer(AbstractServer[WorkerProcess]):
         worker = WSGIWorker(
             worker_id,
             sock,
+            uds_sock,
             ipc,
             runtime_threads,
             runtime_blocking_threads,
@@ -321,22 +352,40 @@ class MPServer(AbstractServer[WorkerProcess]):
             *ssl_ctx,
             metrics,
         )
-        serve = getattr(worker, WORKERS_METHODS[runtime_mode][sock.is_uds()])
+        if sock and uds_sock:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode]['dual'])
+        elif uds_sock:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode][True])
+        else:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode][False])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
         serve(scheduler, loop, shutdown_event)
 
     def _init_shared_socket(self):
         super()._init_shared_socket()
-        sock = socket.socket(fileno=self._sfd)
-        sock.set_inheritable(True)
-        self._sso = sock
+        if self._sfd:
+            sock = socket.socket(fileno=self._sfd)
+            sock.set_inheritable(True)
+            self._sso = sock
+        else:
+            self._sso = None
+
+        if self._sfd_uds:
+            sock = socket.socket(fileno=self._sfd_uds)
+            sock.set_inheritable(True)
+            self._sso_uds = sock
+        else:
+            self._sso_uds = None
 
     def _write_pidfile(self):
         super()._write_pidfile()
         self._rss_collector = ProcInfoCollector()
 
     def _unlink_pidfile(self):
-        self._sso.detach()
+        if self._sso:
+            self._sso.detach()
+        if self._sso_uds:
+            self._sso_uds.detach()
         super()._unlink_pidfile()
 
     def _start_ipc(self):
@@ -407,7 +456,7 @@ class MPServer(AbstractServer[WorkerProcess]):
                 idx + 1,
                 self.process_name,
                 callback_loader,
-                (self._shd, self._sso),
+                ((self._shd, self._sso), (self._shd_uds, self._sso_uds)),
                 # NOTE: given we use IPC only for metrics right now, let's share the pipe
                 #       only if metrics collection is actually enabled.
                 self._ipc[idx][1] if self.metrics_enabled else None,

--- a/granian/server/mt.py
+++ b/granian/server/mt.py
@@ -37,8 +37,9 @@ class WorkerThread(AbstractWorker):
     def wrap_target(target):
         @wraps(target)
         def wrapped(worker_id, sig, callback, sock, loop_impl, *args, **kwargs):
+            sock_tcp, sock_uds = sock
             loop = loops.get(loop_impl)
-            return target(worker_id, sig, callback, sock, loop, *args, **kwargs)
+            return target(worker_id, sig, callback, sock_tcp, sock_uds, loop, *args, **kwargs)
 
         return wrapped
 
@@ -76,6 +77,7 @@ class MTServer(AbstractServer[WorkerThread]):
         shutdown_event: Any,
         callback: Any,
         sock: Any,
+        uds_sock: Any,
         loop: Any,
         runtime_mode: RuntimeModes,
         runtime_threads: int,
@@ -99,7 +101,7 @@ class MTServer(AbstractServer[WorkerThread]):
         worker = ASGIWorker(
             worker_id,
             sock,
-            None,
+            uds_sock,
             runtime_threads,
             runtime_blocking_threads,
             blocking_threads,
@@ -113,7 +115,12 @@ class MTServer(AbstractServer[WorkerThread]):
             *ssl_ctx,
             metrics,
         )
-        serve = getattr(worker, WORKERS_METHODS[runtime_mode][sock.is_uds()])
+        if sock and uds_sock:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode]['dual'])
+        elif uds_sock:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode][True])
+        else:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode][False])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
         serve(scheduler, loop, shutdown_event)
 
@@ -124,6 +131,7 @@ class MTServer(AbstractServer[WorkerThread]):
         shutdown_event: Any,
         callback: Any,
         sock: Any,
+        uds_sock: Any,
         loop: Any,
         runtime_mode: RuntimeModes,
         runtime_threads: int,
@@ -155,7 +163,7 @@ class MTServer(AbstractServer[WorkerThread]):
         worker = ASGIWorker(
             worker_id,
             sock,
-            None,
+            uds_sock,
             runtime_threads,
             runtime_blocking_threads,
             blocking_threads,
@@ -169,7 +177,12 @@ class MTServer(AbstractServer[WorkerThread]):
             *ssl_ctx,
             metrics,
         )
-        serve = getattr(worker, WORKERS_METHODS[runtime_mode][sock.is_uds()])
+        if sock and uds_sock:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode]['dual'])
+        elif uds_sock:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode][True])
+        else:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode][False])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
         serve(scheduler, loop, shutdown_event)
         loop.run_until_complete(lifespan_handler.shutdown())
@@ -181,6 +194,7 @@ class MTServer(AbstractServer[WorkerThread]):
         shutdown_event: Any,
         callback: Any,
         sock: Any,
+        uds_sock: Any,
         loop: Any,
         runtime_mode: RuntimeModes,
         runtime_threads: int,
@@ -206,7 +220,7 @@ class MTServer(AbstractServer[WorkerThread]):
         worker = RSGIWorker(
             worker_id,
             sock,
-            None,
+            uds_sock,
             runtime_threads,
             runtime_blocking_threads,
             blocking_threads,
@@ -220,7 +234,12 @@ class MTServer(AbstractServer[WorkerThread]):
             *ssl_ctx,
             metrics,
         )
-        serve = getattr(worker, WORKERS_METHODS[runtime_mode][sock.is_uds()])
+        if sock and uds_sock:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode]['dual'])
+        elif uds_sock:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode][True])
+        else:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode][False])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
         serve(scheduler, loop, shutdown_event)
         callback_del(loop)
@@ -232,6 +251,7 @@ class MTServer(AbstractServer[WorkerThread]):
         shutdown_event: Any,
         callback: Any,
         sock: Any,
+        uds_sock: Any,
         loop: Any,
         runtime_mode: RuntimeModes,
         runtime_threads: int,
@@ -255,7 +275,7 @@ class MTServer(AbstractServer[WorkerThread]):
         worker = WSGIWorker(
             worker_id,
             sock,
-            None,
+            uds_sock,
             runtime_threads,
             runtime_blocking_threads,
             blocking_threads,
@@ -268,7 +288,12 @@ class MTServer(AbstractServer[WorkerThread]):
             *ssl_ctx,
             metrics,
         )
-        serve = getattr(worker, WORKERS_METHODS[runtime_mode][sock.is_uds()])
+        if sock and uds_sock:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode]['dual'])
+        elif uds_sock:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode][True])
+        else:
+            serve = getattr(worker, WORKERS_METHODS[runtime_mode][False])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
         serve(scheduler, loop, shutdown_event)
 
@@ -283,7 +308,7 @@ class MTServer(AbstractServer[WorkerThread]):
                 idx + 1,
                 sig,
                 callback_loader,
-                self._shd,
+                (self._shd, self._shd_uds),
                 self.loop,
                 self.runtime_mode,
                 self.runtime_threads,

--- a/src/asgi/serve.rs
+++ b/src/asgi/serve.rs
@@ -20,6 +20,7 @@ impl ASGIWorker {
         signature = (
             worker_id,
             sock,
+            uds_sock,
             ipc,
             threads=1,
             blocking_threads=512,
@@ -45,7 +46,8 @@ impl ASGIWorker {
     fn new(
         py: Python,
         worker_id: i32,
-        sock: Py<SocketHolder>,
+        sock: Option<Py<SocketHolder>>,
+        uds_sock: Option<Py<SocketHolder>>,
         ipc: Option<Py<crate::ipc::IPCSenderHandle>>,
         threads: usize,
         blocking_threads: usize,
@@ -71,6 +73,7 @@ impl ASGIWorker {
             config: WorkerConfig::new(
                 worker_id,
                 sock,
+                uds_sock,
                 ipc,
                 threads,
                 blocking_threads,
@@ -198,6 +201,71 @@ impl ASGIWorker {
     ) -> Bound<'p, PyAny> {
         gen_serve_match!(
             crate::serve::serve_fut_uds,
+            WorkerAcceptorUdsPlain,
+            WorkerAcceptorUdsTls,
+            self,
+            (),
+            callback,
+            event_loop,
+            signal,
+            handle,
+            handle_ws
+        )
+    }
+
+    #[cfg(unix)]
+    fn serve_mtr_dual(
+        &self,
+        py: Python,
+        callback: Py<CallbackScheduler>,
+        event_loop: &Bound<PyAny>,
+        signal: Py<WorkerSignal>,
+    ) {
+        crate::serve::gen_serve_match_dual!(
+            crate::serve::serve_mt_dual,
+            WorkerAcceptorTcpPlain,
+            WorkerAcceptorTcpTls,
+            WorkerAcceptorUdsPlain,
+            WorkerAcceptorUdsTls,
+            self,
+            py,
+            callback,
+            event_loop,
+            signal,
+            handle,
+            handle_ws
+        );
+    }
+
+    #[cfg(unix)]
+    fn serve_str_dual(&self, callback: Py<CallbackScheduler>, event_loop: &Bound<PyAny>, signal: Py<WorkerSignal>) {
+        crate::serve::gen_serve_match_dual!(
+            crate::serve::serve_st_dual,
+            WorkerAcceptorTcpPlain,
+            WorkerAcceptorTcpTls,
+            WorkerAcceptorUdsPlain,
+            WorkerAcceptorUdsTls,
+            self,
+            (),
+            callback,
+            event_loop,
+            signal,
+            handle,
+            handle_ws
+        );
+    }
+
+    #[cfg(unix)]
+    fn serve_async_dual<'p>(
+        &self,
+        callback: Py<CallbackScheduler>,
+        event_loop: &Bound<'p, PyAny>,
+        signal: Py<WorkerSignal>,
+    ) -> Bound<'p, PyAny> {
+        crate::serve::gen_serve_match_dual!(
+            crate::serve::serve_fut_dual,
+            WorkerAcceptorTcpPlain,
+            WorkerAcceptorTcpTls,
             WorkerAcceptorUdsPlain,
             WorkerAcceptorUdsTls,
             self,

--- a/src/rsgi/serve.rs
+++ b/src/rsgi/serve.rs
@@ -20,6 +20,7 @@ impl RSGIWorker {
         signature = (
             worker_id,
             sock,
+            uds_sock,
             ipc,
             threads=1,
             blocking_threads=512,
@@ -45,7 +46,8 @@ impl RSGIWorker {
     fn new(
         py: Python,
         worker_id: i32,
-        sock: Py<SocketHolder>,
+        sock: Option<Py<SocketHolder>>,
+        uds_sock: Option<Py<SocketHolder>>,
         ipc: Option<Py<crate::ipc::IPCSenderHandle>>,
         threads: usize,
         blocking_threads: usize,
@@ -71,6 +73,7 @@ impl RSGIWorker {
             config: WorkerConfig::new(
                 worker_id,
                 sock,
+                uds_sock,
                 ipc,
                 threads,
                 blocking_threads,
@@ -198,6 +201,71 @@ impl RSGIWorker {
     ) -> Bound<'p, PyAny> {
         gen_serve_match!(
             crate::serve::serve_fut_uds,
+            WorkerAcceptorUdsPlain,
+            WorkerAcceptorUdsTls,
+            self,
+            (),
+            callback,
+            event_loop,
+            signal,
+            handle,
+            handle_ws
+        )
+    }
+
+    #[cfg(unix)]
+    fn serve_mtr_dual(
+        &self,
+        py: Python,
+        callback: Py<CallbackScheduler>,
+        event_loop: &Bound<PyAny>,
+        signal: Py<WorkerSignal>,
+    ) {
+        crate::serve::gen_serve_match_dual!(
+            crate::serve::serve_mt_dual,
+            WorkerAcceptorTcpPlain,
+            WorkerAcceptorTcpTls,
+            WorkerAcceptorUdsPlain,
+            WorkerAcceptorUdsTls,
+            self,
+            py,
+            callback,
+            event_loop,
+            signal,
+            handle,
+            handle_ws
+        );
+    }
+
+    #[cfg(unix)]
+    fn serve_str_dual(&self, callback: Py<CallbackScheduler>, event_loop: &Bound<PyAny>, signal: Py<WorkerSignal>) {
+        crate::serve::gen_serve_match_dual!(
+            crate::serve::serve_st_dual,
+            WorkerAcceptorTcpPlain,
+            WorkerAcceptorTcpTls,
+            WorkerAcceptorUdsPlain,
+            WorkerAcceptorUdsTls,
+            self,
+            (),
+            callback,
+            event_loop,
+            signal,
+            handle,
+            handle_ws
+        );
+    }
+
+    #[cfg(unix)]
+    fn serve_async_dual<'p>(
+        &self,
+        callback: Py<CallbackScheduler>,
+        event_loop: &Bound<'p, PyAny>,
+        signal: Py<WorkerSignal>,
+    ) -> Bound<'p, PyAny> {
+        crate::serve::gen_serve_match_dual!(
+            crate::serve::serve_fut_dual,
+            WorkerAcceptorTcpPlain,
+            WorkerAcceptorTcpTls,
             WorkerAcceptorUdsPlain,
             WorkerAcceptorUdsTls,
             self,

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -35,7 +35,7 @@ macro_rules! serve_fn {
             let worker_id = cfg.id;
             log::info!("Started worker-{worker_id}");
 
-            let listener = cfg.$listener_gen();
+            let listener = cfg.$listener_gen().expect("Listener missing");
             let backpressure = cfg.backpressure;
 
             let rtpyloop = Arc::new(event_loop.clone().unbind());
@@ -146,7 +146,7 @@ macro_rules! serve_fn {
             for thread_id in 0..cfg.threads {
                 log::info!("Started worker-{} runtime-{}", worker_id, thread_id + 1);
 
-                let listener = cfg.$listener_gen();
+                let listener = cfg.$listener_gen().expect("Listener missing");
                 let blocking_threads = cfg.blocking_threads;
                 let py_threads = cfg.py_threads;
                 let py_threads_idle_timeout = cfg.py_threads_idle_timeout;
@@ -272,7 +272,7 @@ macro_rules! serve_fn {
             let worker_id = cfg.id;
             log::info!("Started worker-{worker_id}");
 
-            let tcp_listener = cfg.$listener_gen();
+            let tcp_listener = cfg.$listener_gen().expect("Listener missing");
             let blocking_threads = cfg.blocking_threads;
             let py_threads = cfg.py_threads;
             let py_threads_idle_timeout = cfg.py_threads_idle_timeout;
@@ -341,6 +341,426 @@ macro_rules! serve_fn {
             ret
         }
     };
+    (mt_dual $name:ident) => {
+        pub(crate) fn $name<C, Atcp, Auds, H, F, M, Ret>(
+            cfg: &WorkerConfig,
+            py: Python,
+            event_loop: &Bound<PyAny>,
+            signal: Py<WorkerSignal>,
+            metrics: (M, Option<crate::metrics::ArcWorkerMetrics>),
+            ctx: C,
+            acceptor_tcp: Atcp,
+            acceptor_uds: Auds,
+            handler: H,
+            target: F,
+        ) where
+            F: Fn(
+                    crate::runtime::RuntimeRef,
+                    Arc<tokio::sync::Notify>,
+                    crate::callbacks::ArcCBScheduler,
+                    crate::net::SockAddr,
+                    crate::net::SockAddr,
+                    crate::http::HTTPRequest,
+                    crate::http::HTTPProto,
+                ) -> Ret
+                + Copy,
+            M: Clone + Sync,
+            Ret: Future<Output = crate::http::HTTPResponse>,
+            C: Clone + Send + Sync + 'static,
+            H: Clone + Send + Sync + 'static,
+            Worker<C, Atcp, H, F, M>: WorkerAcceptor<std::net::TcpListener> + Send + 'static,
+            Worker<C, Auds, H, F, M>: WorkerAcceptor<std::os::unix::net::UnixListener> + Send + 'static,
+        {
+            _ = pyo3_log::try_init();
+
+            let worker_id = cfg.id;
+            log::info!("Started worker-{worker_id}");
+
+            let tcp_listener = cfg.tcp_listener();
+            let uds_listener = cfg.uds_listener();
+            let backpressure = cfg.backpressure;
+
+            let rtpyloop = Arc::new(event_loop.clone().unbind());
+            let rt = py.detach(|| {
+                crate::runtime::init_runtime_mt(
+                    cfg.threads,
+                    cfg.blocking_threads,
+                    cfg.py_threads,
+                    cfg.py_threads_idle_timeout,
+                    rtpyloop,
+                    metrics.1.clone(),
+                )
+            });
+            let rth = rt.handler();
+            let srx = signal.get().rx.lock().unwrap().take().unwrap();
+            let mc_notify = Arc::new(tokio::sync::Notify::new());
+
+            if let Some(metrics_interval) = cfg.metrics.0 {
+                #[cfg(not(Py_GIL_DISABLED))]
+                crate::metrics::spawn_ipc_collector(
+                    rth.clone(),
+                    srx.clone(),
+                    mc_notify.clone(),
+                    metrics.1.clone().unwrap(),
+                    metrics_interval,
+                    cfg.ipc.as_ref().unwrap().clone_ref(py),
+                );
+                #[cfg(Py_GIL_DISABLED)]
+                crate::metrics::spawn_local_collector(
+                    rth.clone(),
+                    srx.clone(),
+                    mc_notify.clone(),
+                    metrics.1.clone().unwrap(),
+                    metrics_interval,
+                    (cfg.id - 1).try_into().unwrap(),
+                    cfg.metrics.1.as_ref().unwrap().clone_ref(py),
+                );
+            } else {
+                mc_notify.notify_one();
+            }
+
+            let wrk_tcp = crate::workers::Worker::new(
+                ctx.clone(),
+                acceptor_tcp,
+                handler.clone(),
+                rth.clone(),
+                target,
+                metrics.0.clone(),
+            );
+            let wrk_uds = crate::workers::Worker::new(ctx, acceptor_uds, handler, rth, target, metrics.0.clone());
+            let tasks_tcp = wrk_tcp.tasks.clone();
+            let tasks_uds = wrk_uds.tasks.clone();
+
+            let main_loop = crate::runtime::run_until_complete(&rt, event_loop.clone(), async move {
+                match (tcp_listener, uds_listener) {
+                    (Some(tcp), Some(uds)) => {
+                        tokio::join!(
+                            wrk_tcp.listen(srx.clone(), tcp, backpressure),
+                            wrk_uds.listen(srx, uds, backpressure)
+                        );
+                    }
+                    (Some(tcp), None) => {
+                        wrk_tcp.listen(srx, tcp, backpressure).await;
+                    }
+                    (None, Some(uds)) => {
+                        wrk_uds.listen(srx, uds, backpressure).await;
+                    }
+                    _ => {}
+                }
+
+                log::info!("Stopping worker-{worker_id}");
+
+                wrk_tcp.rt.close();
+                tasks_tcp.close();
+                tasks_uds.close();
+                tokio::join!(tasks_tcp.wait(), tasks_uds.wait());
+                mc_notify.notified().await;
+
+                Python::attach(|_| {
+                    drop(wrk_tcp);
+                    drop(wrk_uds);
+                });
+                Ok(())
+            });
+
+            drop(rt);
+
+            if let Err(err) = main_loop {
+                log::error!("{err}");
+                std::process::exit(1);
+            }
+        }
+    };
+
+    (st_dual $name:ident) => {
+        pub(crate) fn $name<C, Atcp, Auds, H, F, M, Ret>(
+            cfg: &WorkerConfig,
+            _py: (),
+            event_loop: &Bound<PyAny>,
+            signal: Py<WorkerSignal>,
+            metrics: (M, Option<crate::metrics::ArcWorkerMetrics>),
+            ctx: C,
+            acceptor_tcp: Atcp,
+            acceptor_uds: Auds,
+            handler: H,
+            target: F,
+        ) where
+            F: Fn(
+                    crate::runtime::RuntimeRef,
+                    Arc<tokio::sync::Notify>,
+                    crate::callbacks::ArcCBScheduler,
+                    crate::net::SockAddr,
+                    crate::net::SockAddr,
+                    crate::http::HTTPRequest,
+                    crate::http::HTTPProto,
+                ) -> Ret
+                + Copy
+                + Send,
+            Ret: Future<Output = crate::http::HTTPResponse>,
+            C: Clone + Send + Sync + 'static,
+            Atcp: Clone + Send + 'static,
+            Auds: Clone + Send + 'static,
+            H: Clone + Send + Sync + 'static,
+            M: Clone + Send,
+            Worker<C, Atcp, H, F, M>: WorkerAcceptor<std::net::TcpListener> + Send + 'static,
+            Worker<C, Auds, H, F, M>: WorkerAcceptor<std::os::unix::net::UnixListener> + Send + 'static,
+        {
+            _ = pyo3_log::try_init();
+
+            let worker_id = cfg.id;
+            log::info!("Started worker-{worker_id}");
+
+            let (stx, srx) = tokio::sync::watch::channel(false);
+            let mut workers = vec![];
+
+            let py_loop = Arc::new(event_loop.clone().unbind());
+
+            for thread_id in 0..cfg.threads {
+                log::info!("Started worker-{} runtime-{}", worker_id, thread_id + 1);
+
+                let tcp_listener = cfg.tcp_listener();
+                let uds_listener = cfg.uds_listener();
+                let blocking_threads = cfg.blocking_threads;
+                let py_threads = cfg.py_threads;
+                let py_threads_idle_timeout = cfg.py_threads_idle_timeout;
+                let backpressure = cfg.backpressure;
+                let metrics = metrics.clone();
+                let ctx = ctx.clone();
+                let acceptor_tcp = acceptor_tcp.clone();
+                let acceptor_uds = acceptor_uds.clone();
+                let handler = handler.clone();
+                let target = target.clone();
+                let py_loop = py_loop.clone();
+                let srx = srx.clone();
+
+                workers.push(std::thread::spawn(move || {
+                    let rt = crate::runtime::init_runtime_st(
+                        blocking_threads,
+                        py_threads,
+                        py_threads_idle_timeout,
+                        py_loop,
+                        metrics.1.clone(),
+                    );
+                    let rth = rt.handler();
+                    let wrk_tcp =
+                        crate::workers::Worker::new(ctx.clone(), acceptor_tcp, handler.clone(), rth.clone(), target, metrics.0.clone());
+                    let wrk_uds = crate::workers::Worker::new(ctx, acceptor_uds, handler, rth, target, metrics.0.clone());
+                    let local = tokio::task::LocalSet::new();
+                    let tasks_tcp = wrk_tcp.tasks.clone();
+                    let tasks_uds = wrk_uds.tasks.clone();
+
+                    crate::runtime::block_on_local(&rt, local, async move {
+                        match (tcp_listener, uds_listener) {
+                            (Some(tcp), Some(uds)) => {
+                                tokio::join!(
+                                    wrk_tcp.listen(srx.clone(), tcp, backpressure),
+                                    wrk_uds.listen(srx, uds, backpressure)
+                                );
+                            }
+                            (Some(tcp), None) => {
+                                wrk_tcp.listen(srx, tcp, backpressure).await;
+                            }
+                            (None, Some(uds)) => {
+                                wrk_uds.listen(srx, uds, backpressure).await;
+                            }
+                            _ => {}
+                        }
+
+                        log::info!("Stopping worker-{} runtime-{}", worker_id, thread_id + 1);
+
+                        wrk_tcp.rt.close();
+                        tasks_tcp.close();
+                        tasks_uds.close();
+                        tokio::join!(tasks_tcp.wait(), tasks_uds.wait());
+
+                        Python::attach(|_| {
+                            drop(wrk_tcp);
+                            drop(wrk_uds);
+                        });
+                    });
+
+                    Python::attach(|_| drop(rt));
+                }));
+            }
+
+            let rtm = crate::runtime::init_runtime_mt(1, 1, 0, 0, Arc::new(event_loop.clone().unbind()), None);
+            let mut pyrx = signal.get().rx.lock().unwrap().take().unwrap();
+            let mc_notify = Arc::new(tokio::sync::Notify::new());
+
+            if let Some(metrics_interval) = cfg.metrics.0 {
+                #[cfg(not(Py_GIL_DISABLED))]
+                crate::metrics::spawn_ipc_collector(
+                    rtm.handler(),
+                    pyrx.clone(),
+                    mc_notify.clone(),
+                    metrics.1.clone().unwrap(),
+                    metrics_interval,
+                    cfg.ipc.as_ref().unwrap().clone_ref(event_loop.py()),
+                );
+                #[cfg(Py_GIL_DISABLED)]
+                crate::metrics::spawn_local_collector(
+                    rtm.handler(),
+                    pyrx.clone(),
+                    mc_notify.clone(),
+                    metrics.1.clone().unwrap(),
+                    metrics_interval,
+                    (cfg.id - 1).try_into().unwrap(),
+                    cfg.metrics.1.as_ref().unwrap().clone_ref(event_loop.py()),
+                );
+            } else {
+                mc_notify.notify_one();
+            }
+
+            let main_loop = crate::runtime::run_until_complete(&rtm, event_loop.clone(), async move {
+                let _ = pyrx.changed().await;
+                stx.send(true).unwrap();
+                log::info!("Stopping worker-{worker_id}");
+                while let Some(worker) = workers.pop() {
+                    worker.join().unwrap();
+                }
+                mc_notify.notified().await;
+                Ok(())
+            });
+
+            drop(rtm);
+
+            if let Err(err) = main_loop {
+                log::error!("{err}");
+                std::process::exit(1);
+            }
+        }
+    };
+
+    (fut_dual $name:ident) => {
+        pub(crate) fn $name<'p, C, Atcp, Auds, H, F, M, Ret>(
+            cfg: &WorkerConfig,
+            _py: (),
+            event_loop: &Bound<'p, PyAny>,
+            signal: Py<WorkerSignal>,
+            metrics: (M, Option<crate::metrics::ArcWorkerMetrics>),
+            ctx: C,
+            acceptor_tcp: Atcp,
+            acceptor_uds: Auds,
+            handler: H,
+            target: F,
+        ) -> Bound<'p, PyAny>
+        where
+            F: Fn(
+                    crate::runtime::RuntimeRef,
+                    Arc<tokio::sync::Notify>,
+                    crate::callbacks::ArcCBScheduler,
+                    crate::net::SockAddr,
+                    crate::net::SockAddr,
+                    crate::http::HTTPRequest,
+                    crate::http::HTTPProto,
+                ) -> Ret
+                + Copy
+                + Send,
+            Ret: Future<Output = crate::http::HTTPResponse>,
+            C: Clone + Send + Sync + 'static,
+            Atcp: Clone + Send + 'static,
+            Auds: Clone + Send + 'static,
+            H: Clone + Send + Sync + 'static,
+            M: Clone + Send,
+            Worker<C, Atcp, H, F, M>: WorkerAcceptor<std::net::TcpListener> + Send + 'static,
+            Worker<C, Auds, H, F, M>: WorkerAcceptor<std::os::unix::net::UnixListener> + Send + 'static,
+        {
+            _ = pyo3_log::try_init();
+
+            let worker_id = cfg.id;
+            log::info!("Started worker-{worker_id}");
+
+            let tcp_listener = cfg.tcp_listener();
+            let uds_listener = cfg.uds_listener();
+            let blocking_threads = cfg.blocking_threads;
+            let py_threads = cfg.py_threads;
+            let py_threads_idle_timeout = cfg.py_threads_idle_timeout;
+            let backpressure = cfg.backpressure;
+
+            let (stx, srx) = tokio::sync::watch::channel(false);
+            let pyloop_r1 = Arc::new(event_loop.clone().unbind());
+            let pyloop_r2 = pyloop_r1.clone();
+
+            let worker = std::thread::spawn(move || {
+                let rt = crate::runtime::init_runtime_st(
+                    blocking_threads,
+                    py_threads,
+                    py_threads_idle_timeout,
+                    pyloop_r1,
+                    metrics.1.clone(),
+                );
+                let rth = rt.handler();
+                let wrk_tcp =
+                    crate::workers::Worker::new(ctx.clone(), acceptor_tcp, handler.clone(), rth.clone(), target, metrics.0.clone());
+                let wrk_uds = crate::workers::Worker::new(ctx, acceptor_uds, handler, rth, target, metrics.0.clone());
+                let tasks_tcp = wrk_tcp.tasks.clone();
+                let tasks_uds = wrk_uds.tasks.clone();
+
+                rt.inner.block_on(async move {
+                    match (tcp_listener, uds_listener) {
+                        (Some(tcp), Some(uds)) => {
+                            tokio::join!(
+                                wrk_tcp.listen(srx.clone(), tcp, backpressure),
+                                wrk_uds.listen(srx, uds, backpressure)
+                            );
+                        }
+                        (Some(tcp), None) => {
+                            wrk_tcp.listen(srx, tcp, backpressure).await;
+                        }
+                        (None, Some(uds)) => {
+                            wrk_uds.listen(srx, uds, backpressure).await;
+                        }
+                        _ => {}
+                    }
+
+                    log::info!("Stopping worker-{worker_id}");
+
+                    wrk_tcp.rt.close();
+                    tasks_tcp.close();
+                    tasks_uds.close();
+                    tokio::join!(tasks_tcp.wait(), tasks_uds.wait());
+
+                    Python::attach(|_| {
+                        drop(wrk_tcp);
+                        drop(wrk_uds);
+                    });
+                });
+
+                Python::attach(|_| drop(rt));
+            });
+
+            let ret = event_loop.call_method0("create_future").unwrap();
+            let pyfut = ret.clone().unbind();
+
+            std::thread::spawn(move || {
+                let rt = crate::runtime::init_runtime_st(1, 0, 0, pyloop_r2.clone(), None);
+                let local = tokio::task::LocalSet::new();
+
+                let mut pyrx = signal.get().rx.lock().unwrap().take().unwrap();
+                crate::runtime::block_on_local(&rt, local, async move {
+                    let _ = pyrx.changed().await;
+                    stx.send(true).unwrap();
+                    log::info!("Stopping worker-{worker_id}");
+                    worker.join().unwrap();
+                });
+
+                Python::attach(|py| {
+                    let cb = pyfut.getattr(py, "set_result").unwrap();
+                    _ = pyloop_r2.call_method1(
+                        py,
+                        "call_soon_threadsafe",
+                        (crate::callbacks::PyFutureResultSetter, cb, py.None()),
+                    );
+                    drop(pyfut);
+                    drop(pyloop_r2);
+                    drop(signal);
+                    drop(rt);
+                });
+            });
+
+            ret
+        }
+    };
 }
 
 serve_fn!(mt serve_mt, std::net::TcpListener, tcp_listener);
@@ -352,6 +772,12 @@ serve_fn!(mt serve_mt_uds, std::os::unix::net::UnixListener, uds_listener);
 serve_fn!(st serve_st_uds, std::os::unix::net::UnixListener, uds_listener);
 #[cfg(unix)]
 serve_fn!(fut serve_fut_uds, std::os::unix::net::UnixListener, uds_listener);
+#[cfg(unix)]
+serve_fn!(mt_dual serve_mt_dual);
+#[cfg(unix)]
+serve_fn!(st_dual serve_st_dual);
+#[cfg(unix)]
+serve_fn!(fut_dual serve_fut_dual);
 
 macro_rules! gen_serve_impl {
     ($sm:expr, $self:expr, $py:expr, $event_loop:expr, $signal:expr, $metrics:expr, $metrics_opt:expr, $ctx:expr, $acceptor:expr, $proto:expr, $target:expr) => {{
@@ -574,3 +1000,243 @@ pub(crate) use gen_serve_match;
 pub(crate) use gen_serve_match_files;
 pub(crate) use gen_serve_match_proto;
 pub(crate) use gen_serve_match_tls;
+
+macro_rules! gen_serve_impl_dual {
+    ($sm:expr, $self:expr, $py:expr, $event_loop:expr, $signal:expr, $metrics:expr, $metrics_opt:expr, $ctx:expr, $acceptor_tcp:expr, $acceptor_uds:expr, $proto:expr, $target:expr) => {{
+        $sm(
+            &$self.config,
+            $py,
+            $event_loop,
+            $signal,
+            ($metrics.clone(), $metrics_opt),
+            $ctx,
+            $acceptor_tcp,
+            $acceptor_uds,
+            $proto,
+            $target,
+        )
+    }};
+}
+
+macro_rules! gen_serve_match_proto_dual {
+    ($sm:expr, $self:expr, $py:expr, $event_loop:expr, $signal:expr, $metrics:expr, $metrics_opt:expr, $ctx:expr, $acceptor_tcp:expr, $acceptor_uds:expr, $target:expr, $targetws:expr) => {{
+        match (&$self.config.http_mode[..], $self.config.websockets_enabled) {
+            ("auto", false) => crate::serve::gen_serve_impl_dual!(
+                $sm,
+                $self,
+                $py,
+                $event_loop,
+                $signal,
+                $metrics,
+                $metrics_opt,
+                $ctx,
+                $acceptor_tcp,
+                $acceptor_uds,
+                crate::workers::WorkerHandlerHA {
+                    opts_h1: $self.config.http1_opts.clone(),
+                    opts_h2: $self.config.http2_opts.clone(),
+                    metrics: $metrics.clone(),
+                    _upgrades: std::marker::PhantomData::<crate::workers::WorkerMarkerConnNoUpgrades>,
+                },
+                $target
+            ),
+            ("auto", true) => crate::serve::gen_serve_impl_dual!(
+                $sm,
+                $self,
+                $py,
+                $event_loop,
+                $signal,
+                $metrics,
+                $metrics_opt,
+                $ctx,
+                $acceptor_tcp,
+                $acceptor_uds,
+                crate::workers::WorkerHandlerHA {
+                    opts_h1: $self.config.http1_opts.clone(),
+                    opts_h2: $self.config.http2_opts.clone(),
+                    metrics: $metrics.clone(),
+                    _upgrades: std::marker::PhantomData::<crate::workers::WorkerMarkerConnUpgrades>,
+                },
+                $targetws
+            ),
+            ("1", false) => crate::serve::gen_serve_impl_dual!(
+                $sm,
+                $self,
+                $py,
+                $event_loop,
+                $signal,
+                $metrics,
+                $metrics_opt,
+                $ctx,
+                $acceptor_tcp,
+                $acceptor_uds,
+                crate::workers::WorkerHandlerH1 {
+                    opts: $self.config.http1_opts.clone(),
+                    metrics: $metrics.clone(),
+                    _upgrades: std::marker::PhantomData::<crate::workers::WorkerMarkerConnNoUpgrades>,
+                },
+                $target
+            ),
+            ("1", true) => crate::serve::gen_serve_impl_dual!(
+                $sm,
+                $self,
+                $py,
+                $event_loop,
+                $signal,
+                $metrics,
+                $metrics_opt,
+                $ctx,
+                $acceptor_tcp,
+                $acceptor_uds,
+                crate::workers::WorkerHandlerH1 {
+                    opts: $self.config.http1_opts.clone(),
+                    metrics: $metrics.clone(),
+                    _upgrades: std::marker::PhantomData::<crate::workers::WorkerMarkerConnUpgrades>,
+                },
+                $targetws
+            ),
+            ("2", _) => crate::serve::gen_serve_impl_dual!(
+                $sm,
+                $self,
+                $py,
+                $event_loop,
+                $signal,
+                $metrics,
+                $metrics_opt,
+                $ctx,
+                $acceptor_tcp,
+                $acceptor_uds,
+                crate::workers::WorkerHandlerH2 {
+                    opts: $self.config.http2_opts.clone(),
+                    metrics: $metrics.clone(),
+                },
+                $target
+            ),
+            _ => unreachable!(),
+        }
+    }};
+}
+
+macro_rules! gen_serve_match_tls_dual {
+    ($sm:expr, $self:expr, $py:expr, $event_loop:expr, $signal:expr, $metrics:expr, $metrics_opt:expr, $ctx:expr, $acceptor_tcp_plain:ident, $acceptor_tcp_tls:ident, $acceptor_uds_plain:ident, $acceptor_uds_tls:ident, $target:expr, $targetws:expr) => {{
+        match $self.config.tls_opts.is_some() {
+            false => crate::serve::gen_serve_match_proto_dual!(
+                $sm,
+                $self,
+                $py,
+                $event_loop,
+                $signal,
+                $metrics,
+                $metrics_opt,
+                $ctx,
+                crate::workers::$acceptor_tcp_plain {},
+                crate::workers::$acceptor_uds_plain {},
+                $target,
+                $targetws
+            ),
+            true => crate::serve::gen_serve_match_proto_dual!(
+                $sm,
+                $self,
+                $py,
+                $event_loop,
+                $signal,
+                $metrics,
+                $metrics_opt,
+                $ctx,
+                crate::workers::$acceptor_tcp_tls {
+                    opts: $self.config.tls_cfg().into(),
+                },
+                crate::workers::$acceptor_uds_tls {
+                    opts: $self.config.tls_cfg().into(),
+                },
+                $target,
+                $targetws
+            ),
+        }
+    }};
+}
+
+macro_rules! gen_serve_match_files_dual {
+    ($sm:expr, $self:expr, $py:expr, $event_loop:expr, $signal:expr, $metrics:expr, $metrics_opt:expr, $callback:expr, $acceptor_tcp_plain:ident, $acceptor_tcp_tls:ident, $acceptor_uds_plain:ident, $acceptor_uds_tls:ident, $target:expr, $targetws:expr) => {{
+        match $self.config.static_files.is_some() {
+            false => crate::serve::gen_serve_match_tls_dual!(
+                $sm,
+                $self,
+                $py,
+                $event_loop,
+                $signal,
+                $metrics,
+                $metrics_opt,
+                crate::workers::WorkerCTXBase::new($callback, $metrics.clone()),
+                $acceptor_tcp_plain,
+                $acceptor_tcp_tls,
+                $acceptor_uds_plain,
+                $acceptor_uds_tls,
+                $target,
+                $targetws
+            ),
+            true => crate::serve::gen_serve_match_tls_dual!(
+                $sm,
+                $self,
+                $py,
+                $event_loop,
+                $signal,
+                $metrics,
+                $metrics_opt,
+                crate::workers::WorkerCTXFiles::new($callback, $metrics.clone(), $self.config.static_files.clone()),
+                $acceptor_tcp_plain,
+                $acceptor_tcp_tls,
+                $acceptor_uds_plain,
+                $acceptor_uds_tls,
+                $target,
+                $targetws
+            ),
+        }
+    }};
+}
+
+macro_rules! gen_serve_match_dual {
+    ($sm:expr, $acceptor_tcp_plain:ident, $acceptor_tcp_tls:ident, $acceptor_uds_plain:ident, $acceptor_uds_tls:ident, $self:expr, $py:expr, $callback:expr, $event_loop:expr, $signal:expr, $target:expr, $targetws:expr) => {{
+        let metrics_obj = std::sync::Arc::new(crate::metrics::WorkerMetrics::new());
+        match $self.config.metrics.0.is_some() {
+            false => crate::serve::gen_serve_match_files_dual!(
+                $sm,
+                $self,
+                $py,
+                $event_loop,
+                $signal,
+                (),
+                None,
+                $callback,
+                $acceptor_tcp_plain,
+                $acceptor_tcp_tls,
+                $acceptor_uds_plain,
+                $acceptor_uds_tls,
+                $target,
+                $targetws
+            ),
+            true => crate::serve::gen_serve_match_files_dual!(
+                $sm,
+                $self,
+                $py,
+                $event_loop,
+                $signal,
+                metrics_obj.clone(),
+                Some(metrics_obj.clone()),
+                $callback,
+                $acceptor_tcp_plain,
+                $acceptor_tcp_tls,
+                $acceptor_uds_plain,
+                $acceptor_uds_tls,
+                $target,
+                $targetws
+            ),
+        }
+    }};
+}
+
+pub(crate) use gen_serve_impl_dual;
+pub(crate) use gen_serve_match_dual;
+pub(crate) use gen_serve_match_files_dual;
+pub(crate) use gen_serve_match_proto_dual;
+pub(crate) use gen_serve_match_tls_dual;

--- a/src/workers.rs
+++ b/src/workers.rs
@@ -90,7 +90,8 @@ pub(crate) struct HTTP2Config {
 
 pub(crate) struct WorkerConfig {
     pub id: i32,
-    sock: Py<crate::net::SocketHolder>,
+    tcp_sock: Option<Py<crate::net::SocketHolder>>,
+    uds_sock: Option<Py<crate::net::SocketHolder>>,
     #[cfg(not(Py_GIL_DISABLED))]
     pub ipc: Option<Py<crate::ipc::IPCSenderHandle>>,
     pub threads: usize,
@@ -123,7 +124,8 @@ pub(crate) struct WorkerTlsConfig {
 impl WorkerConfig {
     pub fn new(
         id: i32,
-        sock: Py<crate::net::SocketHolder>,
+        sock: Option<Py<crate::net::SocketHolder>>,
+        uds_sock: Option<Py<crate::net::SocketHolder>>,
         #[allow(unused_variables)] ipc: Option<Py<crate::ipc::IPCSenderHandle>>,
         threads: usize,
         blocking_threads: usize,
@@ -159,7 +161,8 @@ impl WorkerConfig {
 
         Self {
             id,
-            sock,
+            tcp_sock: sock,
+            uds_sock,
             #[cfg(not(Py_GIL_DISABLED))]
             ipc,
             threads,
@@ -177,17 +180,27 @@ impl WorkerConfig {
         }
     }
 
-    pub fn tcp_listener(&self) -> std::net::TcpListener {
-        let listener = self.sock.get().as_tcp_listener().unwrap();
-        _ = listener.set_nonblocking(true);
-        listener
+    pub fn tcp_listener(&self) -> Option<std::net::TcpListener> {
+        match &self.tcp_sock {
+            Some(sock) => {
+                let listener = sock.get().as_tcp_listener().unwrap();
+                _ = listener.set_nonblocking(true);
+                Some(listener)
+            }
+            _ => None,
+        }
     }
 
     #[cfg(unix)]
-    pub fn uds_listener(&self) -> std::os::unix::net::UnixListener {
-        let listener = self.sock.get().as_unix_listener().unwrap();
-        _ = listener.set_nonblocking(true);
-        listener
+    pub fn uds_listener(&self) -> Option<std::os::unix::net::UnixListener> {
+        match &self.uds_sock {
+            Some(sock) => {
+                let listener = sock.get().as_unix_listener().unwrap();
+                _ = listener.set_nonblocking(true);
+                Some(listener)
+            }
+            _ => None,
+        }
     }
 
     pub fn tls_cfg(&self) -> tls_listener::rustls::rustls::ServerConfig {

--- a/src/wsgi/serve.rs
+++ b/src/wsgi/serve.rs
@@ -25,6 +25,7 @@ impl WSGIWorker {
         signature = (
             worker_id,
             sock,
+            uds_sock,
             ipc,
             threads=1,
             blocking_threads=512,
@@ -49,7 +50,8 @@ impl WSGIWorker {
     fn new(
         py: Python,
         worker_id: i32,
-        sock: Py<SocketHolder>,
+        sock: Option<Py<SocketHolder>>,
+        uds_sock: Option<Py<SocketHolder>>,
         ipc: Option<Py<crate::ipc::IPCSenderHandle>>,
         threads: usize,
         blocking_threads: usize,
@@ -74,6 +76,7 @@ impl WSGIWorker {
             config: WorkerConfig::new(
                 worker_id,
                 sock,
+                uds_sock,
                 ipc,
                 threads,
                 blocking_threads,
@@ -183,6 +186,54 @@ impl WSGIWorker {
             handle
         );
     }
+
+    #[cfg(unix)]
+    fn serve_mtr_dual(
+        &self,
+        py: Python,
+        callback: Py<CallbackScheduler>,
+        event_loop: &Bound<PyAny>,
+        signal: Py<WorkerSignalSync>,
+    ) {
+        crate::serve::gen_serve_match_dual!(
+            serve_mt_dual,
+            WorkerAcceptorTcpPlain,
+            WorkerAcceptorTcpTls,
+            WorkerAcceptorUdsPlain,
+            WorkerAcceptorUdsTls,
+            self,
+            py,
+            callback,
+            event_loop,
+            signal,
+            handle,
+            handle
+        );
+    }
+
+    #[cfg(unix)]
+    fn serve_str_dual(
+        &self,
+        py: Python,
+        callback: Py<CallbackScheduler>,
+        event_loop: &Bound<PyAny>,
+        signal: Py<WorkerSignalSync>,
+    ) {
+        crate::serve::gen_serve_match_dual!(
+            serve_st_dual,
+            WorkerAcceptorTcpPlain,
+            WorkerAcceptorTcpTls,
+            WorkerAcceptorUdsPlain,
+            WorkerAcceptorUdsTls,
+            self,
+            py,
+            callback,
+            event_loop,
+            signal,
+            handle,
+            handle
+        );
+    }
 }
 
 macro_rules! serve_fn {
@@ -217,7 +268,7 @@ macro_rules! serve_fn {
             let worker_id = cfg.id;
             log::info!("Started worker-{worker_id}");
 
-            let listener = cfg.$listener_gen();
+            let listener = cfg.$listener_gen().expect("Listener missing");
             let backpressure = cfg.backpressure;
 
             let rtpyloop = Arc::new(event_loop.clone().unbind());
@@ -381,7 +432,7 @@ macro_rules! serve_fn {
             for thread_id in 0..cfg.threads {
                 log::info!("Started worker-{} runtime-{}", worker_id, thread_id + 1);
 
-                let tcp_listener = cfg.$listener_gen();
+                let listener = cfg.$listener_gen().expect("Listener missing");
                 let blocking_threads = cfg.blocking_threads;
                 let py_threads = cfg.py_threads;
                 let py_threads_idle_timeout = cfg.py_threads_idle_timeout;
@@ -407,7 +458,7 @@ macro_rules! serve_fn {
                     let local = tokio::task::LocalSet::new();
 
                     crate::runtime::block_on_local(&rt, local, async move {
-                        wrk.clone().listen(srx, tcp_listener, backpressure).await;
+                        wrk.clone().listen(srx, listener, backpressure).await;
 
                         log::info!("Stopping worker-{} runtime-{}", worker_id, thread_id + 1);
 
@@ -415,6 +466,317 @@ macro_rules! serve_fn {
                         wrk.tasks.wait().await;
 
                         Python::attach(|_| drop(wrk));
+                    });
+
+                    Python::attach(|_| drop(rt));
+                }));
+            }
+
+            let pysig = signal.clone_ref(py);
+            std::thread::spawn(move || {
+                let pyrx = pysig.get().rx.lock().unwrap().take().unwrap();
+                _ = pyrx.recv();
+                stx.send(true).unwrap();
+                log::info!("Stopping worker-{worker_id}");
+                while let Some(worker) = workers.pop() {
+                    worker.join().unwrap();
+                }
+                if let Some(thread) = metrics_thread {
+                    thread.join().unwrap();
+                }
+
+                Python::attach(|py| {
+                    _ = pysig.get().release(py);
+                    drop(pysig);
+                });
+            });
+
+            _ = signal.get().qs.call_method0(py, pyo3::intern!(py, "wait"));
+        }
+    };
+
+    (mt_dual $name:ident) => {
+        pub(crate) fn $name<C, Atcp, Auds, H, F, M, Ret>(
+            cfg: &WorkerConfig,
+            py: Python,
+            event_loop: &Bound<PyAny>,
+            signal: Py<WorkerSignalSync>,
+            metrics: (M, Option<crate::metrics::ArcWorkerMetrics>),
+            ctx: C,
+            acceptor_tcp: Atcp,
+            acceptor_uds: Auds,
+            handler: H,
+            target: F,
+        ) where
+            F: Fn(
+                    crate::runtime::RuntimeRef,
+                    Arc<tokio::sync::Notify>,
+                    crate::callbacks::ArcCBScheduler,
+                    crate::net::SockAddr,
+                    crate::net::SockAddr,
+                    crate::http::HTTPRequest,
+                    HTTPProto,
+                ) -> Ret
+                + Copy,
+            M: Clone + Sync,
+            Ret: Future<Output = crate::http::HTTPResponse>,
+            C: Clone + Send + Sync + 'static,
+            H: Clone + Send + Sync + 'static,
+            Worker<C, Atcp, H, F, M>: WorkerAcceptor<std::net::TcpListener> + Clone + Send + 'static,
+            Worker<C, Auds, H, F, M>: WorkerAcceptor<std::os::unix::net::UnixListener> + Clone + Send + 'static,
+        {
+            _ = pyo3_log::try_init();
+
+            let worker_id = cfg.id;
+            log::info!("Started worker-{worker_id}");
+
+            let tcp_listener = cfg.tcp_listener();
+            let uds_listener = cfg.uds_listener();
+            let backpressure = cfg.backpressure;
+
+            let rtpyloop = Arc::new(event_loop.clone().unbind());
+            let rt = py.detach(|| {
+                crate::runtime::init_runtime_mt(
+                    cfg.threads,
+                    cfg.blocking_threads,
+                    cfg.py_threads,
+                    cfg.py_threads_idle_timeout,
+                    rtpyloop,
+                    metrics.1.clone(),
+                )
+            });
+            let rth = rt.handler();
+            let (stx, srx) = tokio::sync::watch::channel(false);
+            let mc_notify = Arc::new(tokio::sync::Notify::new());
+
+            if let Some(metrics_interval) = cfg.metrics.0 {
+                #[cfg(not(Py_GIL_DISABLED))]
+                crate::metrics::spawn_ipc_collector(
+                    rth.clone(),
+                    srx.clone(),
+                    mc_notify.clone(),
+                    metrics.1.clone().unwrap(),
+                    metrics_interval,
+                    cfg.ipc.as_ref().unwrap().clone_ref(py),
+                );
+                #[cfg(Py_GIL_DISABLED)]
+                crate::metrics::spawn_local_collector(
+                    rth.clone(),
+                    srx.clone(),
+                    mc_notify.clone(),
+                    metrics.1.clone().unwrap(),
+                    metrics_interval,
+                    (cfg.id - 1).try_into().unwrap(),
+                    cfg.metrics.1.as_ref().unwrap().clone_ref(py),
+                );
+            } else {
+                mc_notify.notify_one();
+            }
+
+            let wrk_tcp = crate::workers::Worker::new(ctx.clone(), acceptor_tcp, handler.clone(), rth.clone(), target, metrics.0.clone());
+            let wrk_uds = crate::workers::Worker::new(ctx, acceptor_uds, handler, rth, target, metrics.0.clone());
+
+            let main_loop: JoinHandle<anyhow::Result<()>> = rt.inner.spawn(async move {
+                let wrk_tcp_cloned = wrk_tcp.clone();
+                let wrk_uds_cloned = wrk_uds.clone();
+                match (tcp_listener, uds_listener) {
+                    (Some(tcp), Some(uds)) => {
+                        tokio::join!(
+                            wrk_tcp_cloned.listen(srx.clone(), tcp, backpressure),
+                            wrk_uds_cloned.listen(srx, uds, backpressure)
+                        );
+                    }
+                    (Some(tcp), None) => {
+                        wrk_tcp_cloned.listen(srx, tcp, backpressure).await;
+                    }
+                    (None, Some(uds)) => {
+                        wrk_uds_cloned.listen(srx, uds, backpressure).await;
+                    }
+                    _ => {}
+                }
+
+                log::info!("Stopping worker-{worker_id}");
+
+                wrk_tcp.tasks.close();
+                wrk_uds.tasks.close();
+                tokio::join!(wrk_tcp.tasks.wait(), wrk_uds.tasks.wait());
+                mc_notify.notified().await;
+
+                Python::attach(|_| {
+                    drop(wrk_tcp);
+                    drop(wrk_uds);
+                });
+                Ok(())
+            });
+
+            let pysig = signal.clone_ref(py);
+            std::thread::spawn(move || {
+                let pyrx = pysig.get().rx.lock().unwrap().take().unwrap();
+                _ = pyrx.recv();
+                stx.send(true).unwrap();
+
+                while !main_loop.is_finished() {
+                    std::thread::sleep(std::time::Duration::from_millis(1));
+                }
+
+                Python::attach(|py| {
+                    _ = pysig.get().release(py);
+                    drop(pysig);
+                });
+            });
+
+            _ = signal.get().qs.call_method0(py, pyo3::intern!(py, "wait"));
+        }
+    };
+
+    (st_dual $name:ident) => {
+        pub(crate) fn $name<C, Atcp, Auds, H, F, M, Ret>(
+            cfg: &WorkerConfig,
+            py: Python,
+            event_loop: &Bound<PyAny>,
+            signal: Py<WorkerSignalSync>,
+            metrics: (M, Option<crate::metrics::ArcWorkerMetrics>),
+            ctx: C,
+            acceptor_tcp: Atcp,
+            acceptor_uds: Auds,
+            handler: H,
+            target: F,
+        ) where
+            F: Fn(
+                    crate::runtime::RuntimeRef,
+                    Arc<tokio::sync::Notify>,
+                    crate::callbacks::ArcCBScheduler,
+                    crate::net::SockAddr,
+                    crate::net::SockAddr,
+                    crate::http::HTTPRequest,
+                    HTTPProto,
+                ) -> Ret
+                + Copy
+                + Send,
+            Ret: Future<Output = crate::http::HTTPResponse>,
+            C: Clone + Send + 'static,
+            Atcp: Clone + Send + 'static,
+            Auds: Clone + Send + 'static,
+            H: Clone + Send + 'static,
+            M: Clone + Send,
+            Worker<C, Atcp, H, F, M>: WorkerAcceptor<std::net::TcpListener> + Clone + Send + 'static,
+            Worker<C, Auds, H, F, M>: WorkerAcceptor<std::os::unix::net::UnixListener> + Clone + Send + 'static,
+        {
+            _ = pyo3_log::try_init();
+
+            let worker_id = cfg.id;
+            log::info!("Started worker-{worker_id}");
+
+            let (stx, srx) = tokio::sync::watch::channel(false);
+            let mut workers = vec![];
+            let py_loop = Arc::new(event_loop.clone().unbind());
+            let mc_notify = Arc::new(tokio::sync::Notify::new());
+
+            let metrics_thread = if let Some(metrics_interval) = cfg.metrics.0 {
+                let metrics = metrics.1.clone().unwrap();
+                #[cfg(not(Py_GIL_DISABLED))]
+                let ipc = cfg.ipc.as_ref().map(|v| v.clone_ref(py));
+                #[cfg(Py_GIL_DISABLED)]
+                let aggr = cfg.metrics.1.as_ref().map(|v| v.clone_ref(py));
+                let srx = srx.clone();
+                let py_loop = py_loop.clone();
+
+                let thread = std::thread::spawn(move || {
+                    let rt = crate::runtime::init_runtime_st(1, 0, 0, py_loop, None);
+                    let local = tokio::task::LocalSet::new();
+
+                    #[cfg(not(Py_GIL_DISABLED))]
+                    crate::metrics::spawn_ipc_collector(
+                        rt.handler(),
+                        srx,
+                        mc_notify.clone(),
+                        metrics,
+                        metrics_interval,
+                        ipc.unwrap(),
+                    );
+                    #[cfg(Py_GIL_DISABLED)]
+                    crate::metrics::spawn_local_collector(
+                        rt.handler(),
+                        srx,
+                        mc_notify.clone(),
+                        metrics,
+                        metrics_interval,
+                        (worker_id - 1).try_into().unwrap(),
+                        aggr.unwrap(),
+                    );
+
+                    crate::runtime::block_on_local(&rt, local, async move {
+                        mc_notify.notified().await;
+                    });
+
+                    Python::attach(|_| drop(rt));
+                });
+                Some(thread)
+            } else {
+                mc_notify.notify_one();
+                None
+            };
+
+            for thread_id in 0..cfg.threads {
+                log::info!("Started worker-{} runtime-{}", worker_id, thread_id + 1);
+
+                let tcp_listener = cfg.tcp_listener();
+                let uds_listener = cfg.uds_listener();
+                let blocking_threads = cfg.blocking_threads;
+                let py_threads = cfg.py_threads;
+                let py_threads_idle_timeout = cfg.py_threads_idle_timeout;
+                let backpressure = cfg.backpressure;
+                let metrics = metrics.clone();
+                let ctx = ctx.clone();
+                let acceptor_tcp = acceptor_tcp.clone();
+                let acceptor_uds = acceptor_uds.clone();
+                let handler = handler.clone();
+                let target = target.clone();
+                let py_loop = py_loop.clone();
+                let srx = srx.clone();
+
+                workers.push(std::thread::spawn(move || {
+                    let rt = crate::runtime::init_runtime_st(
+                        blocking_threads,
+                        py_threads,
+                        py_threads_idle_timeout,
+                        py_loop,
+                        metrics.1.clone(),
+                    );
+                    let rth = rt.handler();
+                    let wrk_tcp = crate::workers::Worker::new(ctx.clone(), acceptor_tcp, handler.clone(), rth.clone(), target, metrics.0.clone());
+                    let wrk_uds = crate::workers::Worker::new(ctx, acceptor_uds, handler, rth, target, metrics.0.clone());
+                    let local = tokio::task::LocalSet::new();
+
+                    crate::runtime::block_on_local(&rt, local, async move {
+                        let wrk_tcp_cloned = wrk_tcp.clone();
+                        let wrk_uds_cloned = wrk_uds.clone();
+                        match (tcp_listener, uds_listener) {
+                            (Some(tcp), Some(uds)) => {
+                                tokio::join!(
+                                    wrk_tcp_cloned.listen(srx.clone(), tcp, backpressure),
+                                    wrk_uds_cloned.listen(srx, uds, backpressure)
+                                );
+                            }
+                            (Some(tcp), None) => {
+                                wrk_tcp_cloned.listen(srx, tcp, backpressure).await;
+                            }
+                            (None, Some(uds)) => {
+                                wrk_uds_cloned.listen(srx, uds, backpressure).await;
+                            }
+                            _ => {}
+                        }
+
+                        log::info!("Stopping worker-{} runtime-{}", worker_id, thread_id + 1);
+
+                        wrk_tcp.tasks.close();
+                        wrk_uds.tasks.close();
+                        tokio::join!(wrk_tcp.tasks.wait(), wrk_uds.tasks.wait());
+
+                        Python::attach(|_| {
+                            drop(wrk_tcp);
+                            drop(wrk_uds);
+                        });
                     });
 
                     Python::attach(|_| drop(rt));
@@ -451,3 +813,7 @@ serve_fn!(st serve_st, std::net::TcpListener, tcp_listener);
 serve_fn!(mt serve_mt_uds, std::os::unix::net::UnixListener, uds_listener);
 #[cfg(unix)]
 serve_fn!(st serve_st_uds, std::os::unix::net::UnixListener, uds_listener);
+#[cfg(unix)]
+serve_fn!(mt_dual serve_mt_dual);
+#[cfg(unix)]
+serve_fn!(st_dual serve_st_dual);

--- a/tests/test_dual_socket.py
+++ b/tests/test_dual_socket.py
@@ -1,0 +1,69 @@
+import asyncio
+import multiprocessing as mp
+import os
+import sys
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import httpx
+import pytest
+
+from granian import Granian
+
+
+IS_WIN = sys.platform == 'win32'
+
+
+def _serve(**kwargs):
+    server = Granian(f'tests.apps.{kwargs["interface"]}:app', **kwargs)
+    server.serve()
+
+
+@asynccontextmanager
+async def _server(interface, runtime_mode, **server_kwargs):
+    kwargs = {
+        'interface': interface,
+        'uds': Path('granian.sock'),
+        'address': '127.0.0.1',
+        'port': 8001,
+        'loop': 'asyncio',
+        'blocking_threads': 1,
+        'runtime_mode': runtime_mode,
+        'websockets': False,
+        'workers_kill_timeout': 1,
+    }
+    kwargs.update(server_kwargs)
+
+    proc = mp.get_context('spawn').Process(target=_serve, kwargs=kwargs)
+    proc.start()
+    await asyncio.sleep(1.5)
+
+    try:
+        yield
+    finally:
+        proc.terminate()
+        proc.join(timeout=2)
+        if proc.is_alive():
+            proc.kill()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(IS_WIN, reason='no UDS on win')
+@pytest.mark.parametrize('runtime_mode', ['mt', 'st'])
+async def test_dual_socket_asgi(runtime_mode):
+    # Test both TCP and UDS connectivity
+    async with _server('asgi', runtime_mode):
+        # Test UDS
+        transport_uds = httpx.AsyncHTTPTransport(uds='granian.sock')
+        async with httpx.AsyncClient(transport=transport_uds) as client:
+            res = await client.get('http://granian/info')
+            assert res.status_code == 200
+            data = res.json()
+            assert data['scheme'] == 'http'
+
+        # Test TCP
+        async with httpx.AsyncClient() as client:
+            res = await client.get('http://127.0.0.1:8001/info')
+            assert res.status_code == 200
+            data = res.json()
+            assert data['scheme'] == 'http'


### PR DESCRIPTION
This commit enables Granian to serve on both TCP sockets and Unix Domain Sockets concurrently.

Changes:
- Updated Rust worker implementations (ASGI, RSGI, WSGI) to handle optional dual listeners.
- Enhanced `WorkerConfig` to store both TCP and UDS socket holders.
- Introduced new `serve_*_dual` macros and functions in Rust to manage concurrent listeners using `tokio::join!`.
- Modified Python `cli.py` to allow both `--host` and `--uds` arguments to be specified.
- Updated `AbstractServer` and server implementations (MP, MT) to initialize and pass both sockets to workers.
- Added a new test case `tests/test_dual_socket.py` to verify simultaneous connectivity.
- Updated `granian/_granian.pyi` type stubs to reflect the changes in worker constructors.