### PR TITLE
Add graceful shutdown timeout to avoid granian from stalling on keep-alive

### DIFF
--- a/granian/cli.py
+++ b/granian/cli.py
@@ -323,6 +323,15 @@ def option(*param_decls: str, cls: type[click.Option] | None = None, **attrs: An
     help='The maximum amount of memory (in MiB) a worker can consume before respawn',
 )
 @option(
+    '--graceful-shutdown-timeout',
+    type=Duration(0, 1800),
+    help=(
+        'The maximum amount of time in seconds (or a human-readable duration) to wait for active connections '
+        'to close during shutdown before force-closing them'
+    ),
+    show_default='disabled',
+)
+@option(
     '--workers-kill-timeout',
     type=Duration(1, 1800),
     help='The amount of time in seconds (or a human-readable duration) to wait for killing workers that refused to gracefully stop',
@@ -483,6 +492,7 @@ def cli(
     rss_samples: int,
     workers_lifetime: int | None,
     workers_max_rss: int | None,
+    graceful_shutdown_timeout: int | None,
     workers_kill_timeout: int | None,
     factory: bool,
     working_dir: pathlib.Path | None,
@@ -573,6 +583,7 @@ def cli(
         rss_samples=rss_samples,
         workers_lifetime=workers_lifetime,
         workers_max_rss=workers_max_rss,
+        graceful_shutdown_timeout=graceful_shutdown_timeout,
         workers_kill_timeout=workers_kill_timeout,
         factory=factory,
         working_dir=working_dir,

--- a/granian/server/common.py
+++ b/granian/server/common.py
@@ -121,6 +121,7 @@ class AbstractServer(Generic[WT]):
         rss_samples: int = 1,
         workers_lifetime: int | None = None,
         workers_max_rss: int | None = None,
+        graceful_shutdown_timeout: int | None = None,
         workers_kill_timeout: int | None = None,
         factory: bool = False,
         working_dir: Path | None = None,
@@ -182,6 +183,7 @@ class AbstractServer(Generic[WT]):
         self._rss_wrk_samples = {}
         self.workers_lifetime = workers_lifetime
         self.workers_rss = workers_max_rss * 1024 * 1024 if workers_max_rss else None
+        self.graceful_shutdown_timeout = graceful_shutdown_timeout
         self.workers_kill_timeout = workers_kill_timeout
         self.factory = factory
         self.working_dir = working_dir

--- a/granian/server/embed.py
+++ b/granian/server/embed.py
@@ -184,6 +184,7 @@ class Server(AbstractServer[AsyncWorker]):
                 self.blocking_threads,
                 self.blocking_threads_idle_timeout,
                 self.backpressure,
+                self.graceful_shutdown_timeout,
                 self.task_impl,
                 self.http,
                 self.http1_settings,
@@ -210,6 +211,7 @@ class Server(AbstractServer[AsyncWorker]):
         blocking_threads: int,
         blocking_threads_idle_timeout: int,
         backpressure: int,
+        graceful_shutdown_timeout: int | None,
         task_impl: TaskImpl,
         http_mode: HTTPModes,
         http1_settings: HTTP1Settings | None,
@@ -238,6 +240,7 @@ class Server(AbstractServer[AsyncWorker]):
             static_path,
             *ssl_ctx,
             (None, None),
+            graceful_shutdown_timeout,
         )
         serve = worker.serve_async_uds if sock.is_uds() else worker.serve_async
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
@@ -256,6 +259,7 @@ class Server(AbstractServer[AsyncWorker]):
         blocking_threads: int,
         blocking_threads_idle_timeout: int,
         backpressure: int,
+        graceful_shutdown_timeout: int | None,
         task_impl: TaskImpl,
         http_mode: HTTPModes,
         http1_settings: HTTP1Settings | None,
@@ -292,6 +296,7 @@ class Server(AbstractServer[AsyncWorker]):
             static_path,
             *ssl_ctx,
             (None, None),
+            graceful_shutdown_timeout,
         )
         serve = worker.serve_async_uds if sock.is_uds() else worker.serve_async
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
@@ -311,6 +316,7 @@ class Server(AbstractServer[AsyncWorker]):
         blocking_threads: int,
         blocking_threads_idle_timeout: int,
         backpressure: int,
+        graceful_shutdown_timeout: int | None,
         task_impl: TaskImpl,
         http_mode: HTTPModes,
         http1_settings: HTTP1Settings | None,
@@ -341,6 +347,7 @@ class Server(AbstractServer[AsyncWorker]):
             static_path,
             *ssl_ctx,
             (None, None),
+            graceful_shutdown_timeout,
         )
         serve = worker.serve_async_uds if sock.is_uds() else worker.serve_async
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)

--- a/granian/server/mp.py
+++ b/granian/server/mp.py
@@ -124,6 +124,7 @@ class MPServer(AbstractServer[WorkerProcess]):
         blocking_threads: int,
         blocking_threads_idle_timeout: int,
         backpressure: int,
+        graceful_shutdown_timeout: int | None,
         task_impl: TaskImpl,
         http_mode: HTTPModes,
         http1_settings: HTTP1Settings | None,
@@ -156,6 +157,7 @@ class MPServer(AbstractServer[WorkerProcess]):
             static_path,
             *ssl_ctx,
             metrics,
+            graceful_shutdown_timeout,
         )
         serve = getattr(worker, WORKERS_METHODS[runtime_mode][sock.is_uds()])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
@@ -175,6 +177,7 @@ class MPServer(AbstractServer[WorkerProcess]):
         blocking_threads: int,
         blocking_threads_idle_timeout: int,
         backpressure: int,
+        graceful_shutdown_timeout: int | None,
         task_impl: TaskImpl,
         http_mode: HTTPModes,
         http1_settings: HTTP1Settings | None,
@@ -215,6 +218,7 @@ class MPServer(AbstractServer[WorkerProcess]):
             static_path,
             *ssl_ctx,
             metrics,
+            graceful_shutdown_timeout,
         )
         serve = getattr(worker, WORKERS_METHODS[runtime_mode][sock.is_uds()])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
@@ -235,6 +239,7 @@ class MPServer(AbstractServer[WorkerProcess]):
         blocking_threads: int,
         blocking_threads_idle_timeout: int,
         backpressure: int,
+        graceful_shutdown_timeout: int | None,
         task_impl: TaskImpl,
         http_mode: HTTPModes,
         http1_settings: HTTP1Settings | None,
@@ -269,6 +274,7 @@ class MPServer(AbstractServer[WorkerProcess]):
             static_path,
             *ssl_ctx,
             metrics,
+            graceful_shutdown_timeout,
         )
         serve = getattr(worker, WORKERS_METHODS[runtime_mode][sock.is_uds()])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
@@ -289,6 +295,7 @@ class MPServer(AbstractServer[WorkerProcess]):
         blocking_threads: int,
         blocking_threads_idle_timeout: int,
         backpressure: int,
+        graceful_shutdown_timeout: int | None,
         task_impl: TaskImpl,
         http_mode: HTTPModes,
         http1_settings: HTTP1Settings | None,
@@ -320,6 +327,7 @@ class MPServer(AbstractServer[WorkerProcess]):
             static_path,
             *ssl_ctx,
             metrics,
+            graceful_shutdown_timeout,
         )
         serve = getattr(worker, WORKERS_METHODS[runtime_mode][sock.is_uds()])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
@@ -422,6 +430,7 @@ class MPServer(AbstractServer[WorkerProcess]):
                 self.blocking_threads,
                 self.blocking_threads_idle_timeout,
                 self.backpressure,
+                self.graceful_shutdown_timeout,
                 self.task_impl,
                 self.http,
                 self.http1_settings,

--- a/granian/server/mt.py
+++ b/granian/server/mt.py
@@ -83,6 +83,7 @@ class MTServer(AbstractServer[WorkerThread]):
         blocking_threads: int,
         blocking_threads_idle_timeout: int,
         backpressure: int,
+        graceful_shutdown_timeout: int | None,
         task_impl: TaskImpl,
         http_mode: HTTPModes,
         http1_settings: HTTP1Settings | None,
@@ -112,6 +113,7 @@ class MTServer(AbstractServer[WorkerThread]):
             static_path,
             *ssl_ctx,
             metrics,
+            graceful_shutdown_timeout,
         )
         serve = getattr(worker, WORKERS_METHODS[runtime_mode][sock.is_uds()])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
@@ -131,6 +133,7 @@ class MTServer(AbstractServer[WorkerThread]):
         blocking_threads: int,
         blocking_threads_idle_timeout: int,
         backpressure: int,
+        graceful_shutdown_timeout: int | None,
         task_impl: TaskImpl,
         http_mode: HTTPModes,
         http1_settings: HTTP1Settings | None,
@@ -168,6 +171,7 @@ class MTServer(AbstractServer[WorkerThread]):
             static_path,
             *ssl_ctx,
             metrics,
+            graceful_shutdown_timeout,
         )
         serve = getattr(worker, WORKERS_METHODS[runtime_mode][sock.is_uds()])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
@@ -188,6 +192,7 @@ class MTServer(AbstractServer[WorkerThread]):
         blocking_threads: int,
         blocking_threads_idle_timeout: int,
         backpressure: int,
+        graceful_shutdown_timeout: int | None,
         task_impl: TaskImpl,
         http_mode: HTTPModes,
         http1_settings: HTTP1Settings | None,
@@ -219,6 +224,7 @@ class MTServer(AbstractServer[WorkerThread]):
             static_path,
             *ssl_ctx,
             metrics,
+            graceful_shutdown_timeout,
         )
         serve = getattr(worker, WORKERS_METHODS[runtime_mode][sock.is_uds()])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
@@ -239,6 +245,7 @@ class MTServer(AbstractServer[WorkerThread]):
         blocking_threads: int,
         blocking_threads_idle_timeout: int,
         backpressure: int,
+        graceful_shutdown_timeout: int | None,
         task_impl: TaskImpl,
         http_mode: HTTPModes,
         http1_settings: HTTP1Settings | None,
@@ -267,6 +274,7 @@ class MTServer(AbstractServer[WorkerThread]):
             static_path,
             *ssl_ctx,
             metrics,
+            graceful_shutdown_timeout,
         )
         serve = getattr(worker, WORKERS_METHODS[runtime_mode][sock.is_uds()])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
@@ -291,6 +299,7 @@ class MTServer(AbstractServer[WorkerThread]):
                 self.blocking_threads,
                 self.blocking_threads_idle_timeout,
                 self.backpressure,
+                self.graceful_shutdown_timeout,
                 self.task_impl,
                 self.http,
                 self.http1_settings,

--- a/src/asgi/serve.rs
+++ b/src/asgi/serve.rs
@@ -40,6 +40,7 @@ impl ASGIWorker {
             ssl_crl=vec![],
             ssl_client_verify=false,
             metrics=(None, None),
+            graceful_shutdown_timeout=None,
         )
     )]
     fn new(
@@ -66,6 +67,7 @@ impl ASGIWorker {
         ssl_crl: Vec<String>,
         ssl_client_verify: bool,
         metrics: (Option<u64>, Option<Py<crate::metrics::MetricsAggregator>>),
+        graceful_shutdown_timeout: Option<u64>,
     ) -> PyResult<Self> {
         Ok(Self {
             config: WorkerConfig::new(
@@ -77,6 +79,7 @@ impl ASGIWorker {
                 py_threads,
                 py_threads_idle_timeout,
                 backpressure,
+                graceful_shutdown_timeout,
                 http_mode,
                 worker_http1_config_from_py(py, http1_opts)?,
                 worker_http2_config_from_py(py, http2_opts)?,

--- a/src/rsgi/serve.rs
+++ b/src/rsgi/serve.rs
@@ -40,6 +40,7 @@ impl RSGIWorker {
             ssl_crl=vec![],
             ssl_client_verify=false,
             metrics=(None, None),
+            graceful_shutdown_timeout=None,
         )
     )]
     fn new(
@@ -66,6 +67,7 @@ impl RSGIWorker {
         ssl_crl: Vec<String>,
         ssl_client_verify: bool,
         metrics: (Option<u64>, Option<Py<crate::metrics::MetricsAggregator>>),
+        graceful_shutdown_timeout: Option<u64>,
     ) -> PyResult<Self> {
         Ok(Self {
             config: WorkerConfig::new(
@@ -77,6 +79,7 @@ impl RSGIWorker {
                 py_threads,
                 py_threads_idle_timeout,
                 backpressure,
+                graceful_shutdown_timeout,
                 http_mode,
                 worker_http1_config_from_py(py, http1_opts)?,
                 worker_http2_config_from_py(py, http2_opts)?,

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -77,7 +77,15 @@ macro_rules! serve_fn {
                 mc_notify.notify_one();
             }
 
-            let wrk = crate::workers::Worker::new(ctx, acceptor, handler, rth, target, metrics.0);
+            let wrk = crate::workers::Worker::new(
+                ctx,
+                acceptor,
+                handler,
+                rth,
+                target,
+                metrics.0,
+                cfg.graceful_shutdown_timeout,
+            );
             let tasks = wrk.tasks.clone();
 
             let main_loop = crate::runtime::run_until_complete(&rt, event_loop.clone(), async move {
@@ -142,6 +150,7 @@ macro_rules! serve_fn {
             let mut workers = vec![];
 
             let py_loop = Arc::new(event_loop.clone().unbind());
+            let graceful_shutdown_timeout = cfg.graceful_shutdown_timeout;
 
             for thread_id in 0..cfg.threads {
                 log::info!("Started worker-{} runtime-{}", worker_id, thread_id + 1);
@@ -158,6 +167,7 @@ macro_rules! serve_fn {
                 let target = target.clone();
                 let py_loop = py_loop.clone();
                 let srx = srx.clone();
+                let graceful_shutdown_timeout = graceful_shutdown_timeout;
 
                 workers.push(std::thread::spawn(move || {
                     let rt = crate::runtime::init_runtime_st(
@@ -168,7 +178,15 @@ macro_rules! serve_fn {
                         metrics.1.clone(),
                     );
                     let rth = rt.handler();
-                    let wrk = crate::workers::Worker::new(ctx, acceptor, handler, rth, target, metrics.0);
+                    let wrk = crate::workers::Worker::new(
+                        ctx,
+                        acceptor,
+                        handler,
+                        rth,
+                        target,
+                        metrics.0,
+                        graceful_shutdown_timeout,
+                    );
                     let local = tokio::task::LocalSet::new();
                     let tasks = wrk.tasks.clone();
 
@@ -277,6 +295,7 @@ macro_rules! serve_fn {
             let py_threads = cfg.py_threads;
             let py_threads_idle_timeout = cfg.py_threads_idle_timeout;
             let backpressure = cfg.backpressure;
+            let graceful_shutdown_timeout = cfg.graceful_shutdown_timeout;
 
             let (stx, srx) = tokio::sync::watch::channel(false);
             let pyloop_r1 = Arc::new(event_loop.clone().unbind());
@@ -291,7 +310,15 @@ macro_rules! serve_fn {
                     metrics.1.clone(),
                 );
                 let rth = rt.handler();
-                let wrk = crate::workers::Worker::new(ctx, acceptor, handler, rth, target, metrics.0);
+                let wrk = crate::workers::Worker::new(
+                    ctx,
+                    acceptor,
+                    handler,
+                    rth,
+                    target,
+                    metrics.0,
+                    graceful_shutdown_timeout,
+                );
                 let tasks = wrk.tasks.clone();
 
                 rt.inner.block_on(async move {

--- a/src/workers.rs
+++ b/src/workers.rs
@@ -98,6 +98,7 @@ pub(crate) struct WorkerConfig {
     pub py_threads: usize,
     pub py_threads_idle_timeout: u64,
     pub backpressure: usize,
+    pub graceful_shutdown_timeout: Option<std::time::Duration>,
     pub http_mode: String,
     pub http1_opts: HTTP1Config,
     pub http2_opts: HTTP2Config,
@@ -130,6 +131,7 @@ impl WorkerConfig {
         py_threads: usize,
         py_threads_idle_timeout: u64,
         backpressure: usize,
+        graceful_shutdown_timeout: Option<u64>,
         http_mode: &str,
         http1_opts: HTTP1Config,
         http2_opts: HTTP2Config,
@@ -167,6 +169,7 @@ impl WorkerConfig {
             py_threads,
             py_threads_idle_timeout,
             backpressure,
+            graceful_shutdown_timeout: graceful_shutdown_timeout.map(std::time::Duration::from_secs),
             http_mode: http_mode.into(),
             http1_opts,
             http2_opts,
@@ -295,6 +298,7 @@ pub(crate) struct Worker<C, A, H, F, M> {
     pub tasks: tokio_util::task::TaskTracker,
     target: F,
     metrics: M,
+    graceful_shutdown_timeout: Option<std::time::Duration>,
 }
 
 impl<C, A, H, F, M, Ret> Worker<C, A, H, F, M>
@@ -311,7 +315,15 @@ where
         + Copy,
     Ret: Future<Output = crate::http::HTTPResponse>,
 {
-    pub fn new(ctx: C, acceptor: A, handler: H, rt: crate::runtime::RuntimeRef, target: F, metrics: M) -> Self {
+    pub fn new(
+        ctx: C,
+        acceptor: A,
+        handler: H,
+        rt: crate::runtime::RuntimeRef,
+        target: F,
+        metrics: M,
+        graceful_shutdown_timeout: Option<std::time::Duration>,
+    ) -> Self {
         Self {
             ctx,
             acceptor,
@@ -320,6 +332,7 @@ where
             tasks: tokio_util::task::TaskTracker::new(),
             target,
             metrics,
+            graceful_shutdown_timeout,
         }
     }
 }
@@ -551,6 +564,7 @@ pub(crate) struct WorkerHandlerHA<U, M> {
 
 struct WorkerHandleH1<U, M> {
     opts: HTTP1Config,
+    graceful_shutdown_timeout: Option<std::time::Duration>,
     guard: Arc<tokio::sync::Notify>,
     metrics: M,
     _upgrades: PhantomData<U>,
@@ -558,6 +572,7 @@ struct WorkerHandleH1<U, M> {
 
 struct WorkerHandleH2<M> {
     opts: HTTP2Config,
+    graceful_shutdown_timeout: Option<std::time::Duration>,
     guard: Arc<tokio::sync::Notify>,
     metrics: M,
 }
@@ -565,6 +580,7 @@ struct WorkerHandleH2<M> {
 struct WorkerHandleHA<U, M> {
     opts_h1: HTTP1Config,
     opts_h2: HTTP2Config,
+    graceful_shutdown_timeout: Option<std::time::Duration>,
     guard: Arc<tokio::sync::Notify>,
     metrics: M,
     _upgrades: PhantomData<U>,
@@ -586,6 +602,7 @@ where
     fn handle(&self, guard: Arc<tokio::sync::Notify>) -> impl WorkerHandle<I, S> {
         WorkerHandleH1 {
             opts: self.handler.opts.clone(),
+            graceful_shutdown_timeout: self.graceful_shutdown_timeout,
             guard,
             metrics: self.handler.metrics.clone(),
             _upgrades: PhantomData::<WorkerMarkerConnNoUpgrades>,
@@ -605,6 +622,7 @@ where
     fn handle(&self, guard: Arc<tokio::sync::Notify>) -> impl WorkerHandle<I, S> {
         WorkerHandleH1 {
             opts: self.handler.opts.clone(),
+            graceful_shutdown_timeout: self.graceful_shutdown_timeout,
             guard,
             metrics: self.handler.metrics.clone(),
             _upgrades: PhantomData::<WorkerMarkerConnUpgrades>,
@@ -624,6 +642,7 @@ where
     fn handle(&self, guard: Arc<tokio::sync::Notify>) -> impl WorkerHandle<I, S> {
         WorkerHandleH2 {
             opts: self.handler.opts.clone(),
+            graceful_shutdown_timeout: self.graceful_shutdown_timeout,
             guard,
             metrics: self.handler.metrics.clone(),
         }
@@ -643,6 +662,7 @@ where
         WorkerHandleHA {
             opts_h1: self.handler.opts_h1.clone(),
             opts_h2: self.handler.opts_h2.clone(),
+            graceful_shutdown_timeout: self.graceful_shutdown_timeout,
             guard,
             metrics: self.handler.metrics.clone(),
             _upgrades: PhantomData::<WorkerMarkerConnNoUpgrades>,
@@ -663,6 +683,7 @@ where
         WorkerHandleHA {
             opts_h1: self.handler.opts_h1.clone(),
             opts_h2: self.handler.opts_h2.clone(),
+            graceful_shutdown_timeout: self.graceful_shutdown_timeout,
             guard,
             metrics: self.handler.metrics.clone(),
             _upgrades: PhantomData::<WorkerMarkerConnUpgrades>,
@@ -693,6 +714,16 @@ macro_rules! conn_handle_h1_impl {
             },
             _ = $sig.notified() => {
                 conn.as_mut().graceful_shutdown();
+
+                if let Some(timeout) = $self.graceful_shutdown_timeout {
+                    if tokio::time::timeout(timeout, conn.as_mut()).await.is_err() {
+                        log::debug!(
+                            "Connection did not close within {:?} during shutdown; dropping.",
+                            timeout
+                        );
+                    }
+                    done = true;
+                }
             }
         }
         if !done {
@@ -737,6 +768,16 @@ macro_rules! conn_handle_ha_impl {
             },
             _ = $sig.notified() => {
                 conn.as_mut().graceful_shutdown();
+
+                if let Some(timeout) = $self.graceful_shutdown_timeout {
+                    if tokio::time::timeout(timeout, conn.as_mut()).await.is_err() {
+                        log::debug!(
+                            "Connection did not close within {:?} during shutdown; dropping.",
+                            timeout
+                        );
+                    }
+                    done = true;
+                }
             }
         }
         if !done {
@@ -772,6 +813,16 @@ macro_rules! conn_handle_h2_impl {
             },
             () = $sig.notified() => {
                 conn.as_mut().graceful_shutdown();
+
+                if let Some(timeout) = $self.graceful_shutdown_timeout {
+                    if tokio::time::timeout(timeout, conn.as_mut()).await.is_err() {
+                        log::debug!(
+                            "Connection did not close within {:?} during shutdown; dropping.",
+                            timeout
+                        );
+                    }
+                    done = true;
+                }
             }
         }
         if !done {

--- a/src/wsgi/serve.rs
+++ b/src/wsgi/serve.rs
@@ -44,6 +44,7 @@ impl WSGIWorker {
             ssl_crl=vec![],
             ssl_client_verify=false,
             metrics=(None, None),
+            graceful_shutdown_timeout=None,
         )
     )]
     fn new(
@@ -69,6 +70,7 @@ impl WSGIWorker {
         ssl_crl: Vec<String>,
         ssl_client_verify: bool,
         metrics: (Option<u64>, Option<Py<crate::metrics::MetricsAggregator>>),
+        graceful_shutdown_timeout: Option<u64>,
     ) -> PyResult<Self> {
         Ok(Self {
             config: WorkerConfig::new(
@@ -80,6 +82,7 @@ impl WSGIWorker {
                 py_threads,
                 py_threads_idle_timeout,
                 backpressure,
+                graceful_shutdown_timeout,
                 http_mode,
                 worker_http1_config_from_py(py, http1_opts)?,
                 worker_http2_config_from_py(py, http2_opts)?,
@@ -259,7 +262,15 @@ macro_rules! serve_fn {
                 mc_notify.notify_one();
             }
 
-            let wrk = crate::workers::Worker::new(ctx, acceptor, handler, rth, target, metrics.0);
+            let wrk = crate::workers::Worker::new(
+                ctx,
+                acceptor,
+                handler,
+                rth,
+                target,
+                metrics.0,
+                cfg.graceful_shutdown_timeout,
+            );
 
             let main_loop: JoinHandle<anyhow::Result<()>> = rt.inner.spawn(async move {
                 wrk.clone().listen(srx, listener, backpressure).await;
@@ -393,6 +404,7 @@ macro_rules! serve_fn {
                 let target = target.clone();
                 let py_loop = py_loop.clone();
                 let srx = srx.clone();
+                let graceful_shutdown_timeout = cfg.graceful_shutdown_timeout;
 
                 workers.push(std::thread::spawn(move || {
                     let rt = crate::runtime::init_runtime_st(
@@ -403,7 +415,15 @@ macro_rules! serve_fn {
                         metrics.1.clone(),
                     );
                     let rth = rt.handler();
-                    let wrk = crate::workers::Worker::new(ctx, acceptor, handler, rth, target, metrics.0);
+                    let wrk = crate::workers::Worker::new(
+                        ctx,
+                        acceptor,
+                        handler,
+                        rth,
+                        target,
+                        metrics.0,
+                        graceful_shutdown_timeout,
+                    );
                     let local = tokio::task::LocalSet::new();
 
                     crate::runtime::block_on_local(&rt, local, async move {


### PR DESCRIPTION
Reported in https://github.com/emmett-framework/granian/discussions/605

---

Adds a new --graceful-shutdown-timeout option (disabled by default) to wait for active connections to drain during shutdown before force-closing.

* CLI option: `--graceful-shutdown-timeout`
* Python server plumbing (MP/MT/embed): passes the value down into workers
* Rust worker config: stores `graceful_shutdown_timeout`
* Rust connection handlers (h1/h2/h1+h2): on shutdown, wait up to the timeout; if exceeded, drop the connection future so the task ends and the worker can exit

### What changes where (high level)

* `granian/cli.py`: new option + pass into `Server(...)`
* `granian/server/common.py`: store `self.graceful_shutdown_timeout`
* `granian/server/mp.py`, `granian/server/mt.py`, `granian/server/embed.py`: pass into `ASGIWorker` / `RSGIWorker` / `WSGIWorker`
* `src/asgi/serve.rs`, `src/rsgi/serve.rs`, `src/wsgi/serve.rs`: accept the arg in the pyo3 worker constructors and pass into `WorkerConfig::new`
* `src/workers.rs`: store the timeout in `WorkerConfig`, pass into `Worker`, and enforce the timeout in the per-connection shutdown path

---

_Below is a discussion I had with GPT Pro_

Uvicorn solves not hanging when restarting by **actively closing idle connections during shutdown**, and (optionally) **putting an upper bound on how long it will wait** for in‑flight work before cancelling it.

## What uvicorn does

### 1) On shutdown it tells every open connection to shut down

In `uvicorn/server.py`, `Server.shutdown()`:

* stops accepting new connections (closes the servers / sockets),
* then iterates over existing connections and calls `connection.shutdown()`,
* then waits for remaining tasks to finish, optionally bounded by `timeout_graceful_shutdown` (and cancels tasks if that timeout is exceeded).

That’s why “Ctrl+C feels instant”: it doesn’t wait for clients to eventually close keep‑alive sockets—it forces them to close if they’re idle.

### 2) Each HTTP connection decides whether it can close immediately

In both HTTP protocol implementations:

* `uvicorn/protocols/http/h11_impl.py` → `shutdown()`
* `uvicorn/protocols/http/httptools_impl.py` → `shutdown()`

The logic is essentially:

* **If there is no response currently in progress**, close the transport immediately (`transport.close()`).
* **If a response is in progress**, don’t cut it off, but **disable keep‑alive** so the connection closes as soon as the response finishes.

So it’s not “disable keep‑alive always”; it’s “disable keep‑alive *during shutdown if needed*”.

### 3) It also has keep‑alive and graceful-shutdown timeouts

* `timeout_keep_alive` defaults to **5s** in `uvicorn/config.py` (normal runtime behavior).
* `timeout_graceful_shutdown` defaults to **None**, but if you set it, uvicorn will stop waiting and cancel tasks after that period.

And it has the “second Ctrl+C forces exit” behavior (`force_exit`) in `uvicorn/server.py` as well.

## Why granian can stall today

Granian’s current shutdown path (in Rust) does:

* stop accepting new connections,
* notify all connection tasks,
* for each connection task: call Hyper’s `graceful_shutdown()`,
* **then still await the connection future to complete**,
* and finally the worker waits for all tasks to finish.

The stall you described is exactly what happens when a client (browser) keeps an HTTP/1.1 keep‑alive socket open and Hyper’s “graceful shutdown” path doesn’t actually complete promptly for that connection: the task never finishes, and the worker never exits. That’s the behavior in your linked discussion too. 
