### PR TITLE
Fixes #804: Update PyO3 and test dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: workflow_dispatch
 permissions: {}
 
 env:
-  PY_ALL: 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11
+  PY_ALL: 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t pypy3.11
 
 jobs:
   wheels:
@@ -23,39 +23,39 @@ jobs:
           - os: ubuntu
             platform: linux
             target: x86_64
-            interpreter: 3.10 3.11 3.12 3.13 3.14 pypy3.11
+            interpreter: 3.10 3.11 3.12 3.13 3.14 3.15 pypy3.11
           - os: ubuntu
             platform: linux
             target: x86_64
-            interpreter: 3.13t 3.14t
+            interpreter: 3.14t 3.15t
             allocator: mimalloc
           - os: ubuntu
             platform: linux
             target: i686
-            interpreter: 3.10 3.11 3.12 3.13 3.14
+            interpreter: 3.10 3.11 3.12 3.13 3.14 3.15
             allocator: jemalloc
           - os: ubuntu
             platform: linux
             target: i686
-            interpreter: 3.13t 3.14t
+            interpreter: 3.14t 3.15t
             allocator: mimalloc
           - os: ubuntu
             platform: linux
             target: aarch64
             # rust-cross/manylinux2014-cross:aarch64 has issues with `ring`
             container: ghcr.io/rust-cross/manylinux_2_28-cross:aarch64
-            interpreter: 3.10 3.11 3.12 3.13 3.14 pypy3.11
+            interpreter: 3.10 3.11 3.12 3.13 3.14 3.15 pypy3.11
           - os: ubuntu
             platform: linux
             target: aarch64
             # rust-cross/manylinux2014-cross:aarch64 has issues with `ring`
             container: ghcr.io/rust-cross/manylinux_2_28-cross:aarch64
-            interpreter: 3.13t 3.14t
+            interpreter: 3.14t 3.15t
             allocator: mimalloc
           - os: ubuntu
             platform: linux
             target: armv7
-            interpreter: 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t
+            interpreter: 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t
             allocator: jemalloc
           - os: ubuntu
             platform: linux
@@ -74,21 +74,21 @@ jobs:
             allocator: mimalloc
           - os: macos
             target: x86_64
-            interpreter: 3.10 3.11 3.12 3.13 3.14 pypy3.11
+            interpreter: 3.10 3.11 3.12 3.13 3.14 3.15 pypy3.11
           - os: macos
             target: x86_64
-            interpreter: 3.13t 3.14t
+            interpreter: 3.14t 3.15t
             allocator: mimalloc
           - os: macos
             target: aarch64
-            interpreter: 3.10 3.11 3.12 3.13 3.14 pypy3.11
+            interpreter: 3.10 3.11 3.12 3.13 3.14 3.15 pypy3.11
           - os: macos
             target: aarch64
-            interpreter: 3.13t 3.14t
+            interpreter: 3.14t 3.15t
             allocator: mimalloc
           - os: windows
             target: x86_64
-            interpreter: 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11
+            interpreter: 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t pypy3.11
             allocator: mimalloc
 
     runs-on: ${{ matrix.os }}-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 permissions: {}
 
 env:
-  PY_ALL: 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11
+  PY_ALL: 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t pypy3.11
 
 jobs:
   sdist:
@@ -46,39 +46,39 @@ jobs:
           - os: ubuntu
             platform: linux
             target: x86_64
-            interpreter: 3.10 3.11 3.12 3.13 3.14 pypy3.11
+            interpreter: 3.10 3.11 3.12 3.13 3.14 3.15 pypy3.11
           - os: ubuntu
             platform: linux
             target: x86_64
-            interpreter: 3.13t 3.14t
+            interpreter: 3.14t 3.15t
             allocator: mimalloc
           - os: ubuntu
             platform: linux
             target: i686
-            interpreter: 3.10 3.11 3.12 3.13 3.14
+            interpreter: 3.10 3.11 3.12 3.13 3.14 3.15
             allocator: jemalloc
           - os: ubuntu
             platform: linux
             target: i686
-            interpreter: 3.13t 3.14t
+            interpreter: 3.14t 3.15t
             allocator: mimalloc
           - os: ubuntu
             platform: linux
             target: aarch64
             # rust-cross/manylinux2014-cross:aarch64 has issues with `ring`
             container: ghcr.io/rust-cross/manylinux_2_28-cross:aarch64
-            interpreter: 3.10 3.11 3.12 3.13 3.14 pypy3.11
+            interpreter: 3.10 3.11 3.12 3.13 3.14 3.15 pypy3.11
           - os: ubuntu
             platform: linux
             target: aarch64
             # rust-cross/manylinux2014-cross:aarch64 has issues with `ring`
             container: ghcr.io/rust-cross/manylinux_2_28-cross:aarch64
-            interpreter: 3.13t 3.14t
+            interpreter: 3.14t 3.15t
             allocator: mimalloc
           - os: ubuntu
             platform: linux
             target: armv7
-            interpreter: 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t
+            interpreter: 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t
             allocator: jemalloc
           - os: ubuntu
             platform: linux
@@ -97,21 +97,21 @@ jobs:
             allocator: mimalloc
           - os: macos
             target: x86_64
-            interpreter: 3.10 3.11 3.12 3.13 3.14 pypy3.11
+            interpreter: 3.10 3.11 3.12 3.13 3.14 3.15 pypy3.11
           - os: macos
             target: x86_64
-            interpreter: 3.13t 3.14t
+            interpreter: 3.14t 3.15t
             allocator: mimalloc
           - os: macos
             target: aarch64
-            interpreter: 3.10 3.11 3.12 3.13 3.14 pypy3.11
+            interpreter: 3.10 3.11 3.12 3.13 3.14 3.15 pypy3.11
           - os: macos
             target: aarch64
-            interpreter: 3.13t 3.14t
+            interpreter: 3.14t 3.15t
             allocator: mimalloc
           - os: windows
             target: x86_64
-            interpreter: 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11
+            interpreter: 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t pypy3.11
             allocator: mimalloc
 
     runs-on: ${{ matrix.os }}-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,8 @@ jobs:
         include:
           - python-version: 3.14t
             allocator: mimalloc
+          - python-version: 3.15t
+            allocator: mimalloc
 
     env:
       UV_PYTHON: ${{ matrix.python-version }}
@@ -74,6 +76,8 @@ jobs:
         - '3.15'
         include:
           - python-version: 3.14t
+            allocator: mimalloc
+          - python-version: 3.15t
             allocator: mimalloc
 
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
         - '3.12'
         - '3.13'
         - '3.14'
+        - '3.15'
         - pypy3.11
         include:
           - python-version: 3.14t
@@ -70,6 +71,7 @@ jobs:
         - '3.12'
         - '3.13'
         - '3.14'
+        - '3.15'
         include:
           - python-version: 3.14t
             allocator: mimalloc
@@ -111,6 +113,8 @@ jobs:
         - '3.13'
         - '3.14'
         - '3.14t'
+        - '3.15'
+        - '3.15t'
 
     env:
       UV_PYTHON: ${{ matrix.python-version }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,12 +59,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "autocfg"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -687,15 +681,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "inout"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,15 +754,6 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mimalloc"
@@ -1008,38 +984,34 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "anyhow",
  "bytes",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "python3-dll-a",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1047,8 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-log"
-version = "0.13.1"
-source = "git+https://github.com/gi0baro/pyo3-log.git?branch=pyo3-027#5725d1dc79f34c6286938d3be8bcd89e540bae76"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64083bd3a16a353d9d62335808e8e13d0552d2a2b83fdb084496192dcfa9fcd"
 dependencies = [
  "arc-swap",
  "log",
@@ -1057,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1069,24 +1042,14 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.27.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "python3-dll-a"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80ba7540edb18890d444c5aa8e1f1f99b1bdf26fb26ae383135325f4a36042b"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -1562,12 +1525,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "universal-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ pem = "=3.0"
 percent-encoding = "=2.3"
 pin-project-lite = "=0.2"
 pkcs8 = { version = "=0.11", features = ["encryption", "pkcs5"] }
-pyo3 = { version = "=0.27", features = ["anyhow", "bytes", "extension-module", "generate-import-lib"] }
-pyo3-log = { version = "=0.13", git = "https://github.com/gi0baro/pyo3-log.git", branch = "pyo3-027" }
+pyo3 = { version = "=0.29", features = ["anyhow", "bytes", "extension-module", "generate-import-lib"] }
+pyo3-log = { version = "=0.13.4" }
 rustls-pemfile = "2.2"
 serde = { version = "1.0.228", features = ["derive"] }
 socket2 = { version = "=0.6", features = ["all"] }
@@ -64,7 +64,7 @@ tokio-tungstenite = "=0.29"
 tokio-util = { version = "0.7", features = ["codec", "rt"] }
 
 [build-dependencies]
-pyo3-build-config = "=0.27"
+pyo3-build-config = "=0.29"
 
 [features]
 jemalloc = ["dep:tikv-jemallocator"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,10 +73,10 @@ lint = [
 ]
 test = [
     'httpx~=0.28',
-    'pytest~=8.3',
-    'pytest-asyncio~=0.26',
+    'pytest~=9.0',
+    'pytest-asyncio~=1.3',
     'sniffio~=1.3',
-    'websockets~=15.0',
+    'websockets~=16.0',
 ]
 
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ Source = 'https://github.com/emmett-framework/granian'
 
 [dependency-groups]
 build = [
-    'maturin~=1.13.0',
+    'maturin~=1.14',
 ]
 lint = [
     'ruff~=0.15.0',
@@ -89,7 +89,7 @@ all = [
 granian = 'granian:cli.entrypoint'
 
 [build-system]
-requires = ['maturin>=1.8.0,<1.14.0']
+requires = ['maturin>=1.14.0,<2']
 build-backend = 'maturin'
 
 [tool.maturin]

--- a/src/asgi/io.rs
+++ b/src/asgi/io.rs
@@ -285,7 +285,7 @@ impl ASGIHTTPProtocol {
                                 res
                             }
                             Err(_) => {
-                                log::info!("Cannot open file {}", file_path);
+                                log::info!("Cannot open file {file_path}");
                                 response_404()
                             }
                         };

--- a/src/asgi/io.rs
+++ b/src/asgi/io.rs
@@ -285,7 +285,7 @@ impl ASGIHTTPProtocol {
                                 res
                             }
                             Err(_) => {
-                                log::info!("Cannot open file {}", &file_path);
+                                log::info!("Cannot open file {}", file_path);
                                 response_404()
                             }
                         };

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -124,7 +124,10 @@ impl CallbackScheduler {
 impl CallbackScheduler {
     #[inline]
     pub(crate) fn schedule<T>(&self, py: Python, watcher: Py<T>) {
-        let cbarg = (watcher,).into_pyobject(py).unwrap().into_ptr();
+        let cbarg = (watcher.into_bound(py).into_any(),)
+            .into_pyobject(py)
+            .unwrap()
+            .into_ptr();
         let sched = self.schedule_fn.get().unwrap().as_ptr();
 
         unsafe {

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -124,10 +124,7 @@ impl CallbackScheduler {
 impl CallbackScheduler {
     #[inline]
     pub(crate) fn schedule<T>(&self, py: Python, watcher: Py<T>) {
-        let cbarg = (watcher.into_bound(py).into_any(),)
-            .into_pyobject(py)
-            .unwrap()
-            .into_ptr();
+        let cbarg = (watcher.into_any(),).into_pyobject(py).unwrap().into_ptr();
         let sched = self.schedule_fn.get().unwrap().as_ptr();
 
         unsafe {

--- a/src/net.rs
+++ b/src/net.rs
@@ -48,7 +48,7 @@ impl SockAddr {
     }
 }
 
-#[pyclass(frozen, module = "granian._granian")]
+#[pyclass(frozen, module = "granian._granian", from_py_object)]
 #[derive(Clone)]
 pub struct ListenerSpec {
     inp: (String, u16, i32),
@@ -58,7 +58,7 @@ pub struct ListenerSpec {
 }
 
 #[cfg(unix)]
-#[pyclass(frozen, module = "granian._granian")]
+#[pyclass(frozen, module = "granian._granian", from_py_object)]
 #[derive(Clone)]
 pub struct UnixListenerSpec {
     inp: (String, i32),

--- a/src/net.rs
+++ b/src/net.rs
@@ -48,7 +48,7 @@ impl SockAddr {
     }
 }
 
-#[pyclass(frozen, module = "granian._granian", from_py_object)]
+#[pyclass(frozen, from_py_object, module = "granian._granian")]
 #[derive(Clone)]
 pub struct ListenerSpec {
     inp: (String, u16, i32),
@@ -58,7 +58,7 @@ pub struct ListenerSpec {
 }
 
 #[cfg(unix)]
-#[pyclass(frozen, module = "granian._granian", from_py_object)]
+#[pyclass(frozen, from_py_object, module = "granian._granian")]
 #[derive(Clone)]
 pub struct UnixListenerSpec {
     inp: (String, i32),

--- a/src/rsgi/types.rs
+++ b/src/rsgi/types.rs
@@ -17,7 +17,7 @@ use crate::{
 
 const RSGI_PROTO_VERSION: &str = "1.6";
 
-#[pyclass(frozen, module = "granian._granian")]
+#[pyclass(frozen, module = "granian._granian", from_py_object)]
 #[derive(Clone)]
 pub(crate) struct RSGIHeaders {
     inner: HeaderMap,

--- a/src/rsgi/types.rs
+++ b/src/rsgi/types.rs
@@ -17,7 +17,7 @@ use crate::{
 
 const RSGI_PROTO_VERSION: &str = "1.6";
 
-#[pyclass(frozen, module = "granian._granian", from_py_object)]
+#[pyclass(frozen, from_py_object, module = "granian._granian")]
 #[derive(Clone)]
 pub(crate) struct RSGIHeaders {
     inner: HeaderMap,
@@ -295,7 +295,7 @@ impl PyResponseFile {
                 res
             }
             Err(_) => {
-                log::info!("Cannot open file {}", &self.file_path);
+                log::info!("Cannot open file {}", self.file_path);
                 response_404()
             }
         }
@@ -321,7 +321,7 @@ impl PyResponseFileRange {
         match File::open(&self.file_path).await {
             Ok(mut file) => {
                 if file.seek(SeekFrom::Start(self.start)).await.is_err() {
-                    log::error!("Cannot seek to position {} in file {}", self.start, &self.file_path);
+                    log::error!("Cannot seek to position {} in file {}", self.start, self.file_path);
                     return response_500();
                 }
                 let take = file.take(self.end - self.start);
@@ -333,7 +333,7 @@ impl PyResponseFileRange {
                 res
             }
             Err(_) => {
-                log::info!("Cannot open file {}", &self.file_path);
+                log::info!("Cannot open file {}", self.file_path);
                 response_404()
             }
         }


### PR DESCRIPTION
Fixes #804: This updates PyO3 to 0.28 and the test dependencies to their current major versions.
With these update these warnings from the tests are fixed:
```
tests/test_asgi.py::test_scope[mt]
.venv/lib/python3.14/site-packages/pytest_asyncio/plugin.py:978
  /home/tgenannt/LocalGit/granian/.venv/lib/python3.14/site-packages/pytest_asyncio/plugin.py:978: DeprecationWarning: 'asyncio.get_event_loop_policy' is deprecated and slated for removal in Python 3.16
    policy = asyncio.get_event_loop_policy()
```