### PR TITLE
Fix crash on shutdown

### DIFF
--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -111,6 +111,7 @@ impl IPCReceiverHandle {
                 Python::attach(|_| {
                     drop(ipc);
                     drop(metrics_aggregator);
+                    drop(handle);
                 });
             });
 


### PR DESCRIPTION
Fixes #846 
Note: generated with Claude assistance

The first commit makes the most sense, to drop the handle. And fixes the crash.

During my testing with profiling, the 2nd commit came up as another race and seems like an optional, larger fix, but makes sense for fixing on most Python versions.