### PR TITLE
Add zizmor to pre-commit and harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,13 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every month
       interval: "monthly"
+    cooldown:
+      default-days: 7
   # Enable updates for Cargo
   - package-ecosystem: "cargo"
     target-branch: "master"
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,20 +2,23 @@ name: benchmarks
 
 on: workflow_dispatch
 
+permissions: {}
+
 jobs:
   toolchain:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        default: true
-        profile: minimal
+    - name: Install Rust toolchain
+      run: |
+        rustup toolchain install stable --profile minimal --no-self-update
+        rustup default stable
     - run: |
         git clone https://github.com/gi0baro/rewrk.git
         cd rewrk && cargo build --release
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: rewrk
         path: rewrk/target/release/rewrk
@@ -23,18 +26,22 @@ jobs:
   benchmark-base:
     runs-on: ubuntu-latest
     needs: [toolchain]
+    permissions:
+      contents: read
 
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.11'
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: rewrk
     - run: |
         sudo mv rewrk /usr/local/bin && chmod +x /usr/local/bin/rewrk
-    - uses: pyo3/maturin-action@v1
+    - uses: pyo3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
       with:
         command: build
         args: --release --interpreter python3.11
@@ -49,7 +56,7 @@ jobs:
       run: |
         python benchmarks.py
     - name: upload results
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: results-base
         path: benchmarks/results/*
@@ -57,18 +64,22 @@ jobs:
   benchmark-vs:
     runs-on: ubuntu-latest
     needs: [toolchain]
+    permissions:
+      contents: read
 
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.11'
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: rewrk
     - run: |
         sudo mv rewrk /usr/local/bin && chmod +x /usr/local/bin/rewrk
-    - uses: pyo3/maturin-action@v1
+    - uses: pyo3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
       with:
         command: build
         args: --release --interpreter python3.11
@@ -87,20 +98,24 @@ jobs:
       run: |
         python benchmarks.py vs
     - name: upload results
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: results-vs
         path: benchmarks/results/*
 
   benchmark-ws:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.11'
-    - uses: pyo3/maturin-action@v1
+    - uses: pyo3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
       with:
         command: build
         args: --release --interpreter python3.11
@@ -119,7 +134,7 @@ jobs:
       run: |
         python benchmarks.py vs_ws
     - name: upload results
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: results-ws
         path: benchmarks/results/*
@@ -127,22 +142,26 @@ jobs:
   benchmark-pyver:
     runs-on: ubuntu-latest
     needs: [toolchain]
+    permissions:
+      contents: read
 
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: |
           3.10
           3.11
           3.12
           3.13
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: rewrk
     - run: |
         sudo mv rewrk /usr/local/bin && chmod +x /usr/local/bin/rewrk
-    - uses: pyo3/maturin-action@v1
+    - uses: pyo3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
       with:
         command: build
         args: --release --interpreter python3.10 python3.11 python3.12 python3.13
@@ -160,18 +179,20 @@ jobs:
         .venv312/bin/pip install $(ls target/wheels/granian-*-cp312-*.whl)
         .venv313/bin/pip install $(ls target/wheels/granian-*-cp313-*.whl)
     - name: benchmark
-      working-directory: ./benchmarks
+      env:
+        WORKSPACE: ${{ github.workspace }}
       run: |
-        BENCHMARK_EXC_PREFIX=${{ github.workspace }}/.venv310/bin ${{ github.workspace }}/.venv310/bin/python benchmarks.py interfaces
+        cd benchmarks
+        BENCHMARK_EXC_PREFIX="$WORKSPACE/.venv310/bin" "$WORKSPACE/.venv310/bin/python" benchmarks.py interfaces
         mv results/data.json results/py310.json
-        BENCHMARK_EXC_PREFIX=${{ github.workspace }}/.venv311/bin ${{ github.workspace }}/.venv311/bin/python benchmarks.py interfaces
+        BENCHMARK_EXC_PREFIX="$WORKSPACE/.venv311/bin" "$WORKSPACE/.venv311/bin/python" benchmarks.py interfaces
         mv results/data.json results/py311.json
-        BENCHMARK_EXC_PREFIX=${{ github.workspace }}/.venv312/bin ${{ github.workspace }}/.venv312/bin/python benchmarks.py interfaces
+        BENCHMARK_EXC_PREFIX="$WORKSPACE/.venv312/bin" "$WORKSPACE/.venv312/bin/python" benchmarks.py interfaces
         mv results/data.json results/py312.json
-        BENCHMARK_EXC_PREFIX=${{ github.workspace }}/.venv313/bin ${{ github.workspace }}/.venv313/bin/python benchmarks.py interfaces
+        BENCHMARK_EXC_PREFIX="$WORKSPACE/.venv313/bin" "$WORKSPACE/.venv313/bin/python" benchmarks.py interfaces
         mv results/data.json results/py313.json
     - name: upload results
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: results-pyver
         path: benchmarks/results/*
@@ -179,29 +200,34 @@ jobs:
   results:
     runs-on: ubuntu-latest
     needs: [benchmark-base, benchmark-vs, benchmark-ws, benchmark-pyver]
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
-    - uses: actions/checkout@v6
-    - uses: gi0baro/setup-noir@v1
-    - uses: actions/download-artifact@v8
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: gi0baro/setup-noir@c377f5ef3a1e4d0b85578ebd1ae2a8965988d8f9 # v1.0.0
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: results-base
         path: benchmarks/results
     - run: |
         mv benchmarks/results/data.json benchmarks/results/base.json
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: results-vs
         path: benchmarks/results
     - run: |
         mv benchmarks/results/data.json benchmarks/results/vs.json
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: results-ws
         path: benchmarks/results
     - run: |
         mv benchmarks/results/data.json benchmarks/results/ws.json
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: results-pyver
         path: benchmarks/results
@@ -218,7 +244,7 @@ jobs:
           -v pyvb=310 -v 'benv=GHA Linux x86_64' \
           templates/pyver.md > pyver.md
     - name: open PR
-      uses: peter-evans/create-pull-request@v8
+      uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
       with:
         branch: benchmarks-update
         branch-suffix: timestamp

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -181,8 +181,8 @@ jobs:
     - name: benchmark
       env:
         WORKSPACE: ${{ github.workspace }}
+      working-directory: ./benchmarks
       run: |
-        cd benchmarks
         BENCHMARK_EXC_PREFIX="$WORKSPACE/.venv310/bin" "$WORKSPACE/.venv310/bin/python" benchmarks.py interfaces
         mv results/data.json results/py310.json
         BENCHMARK_EXC_PREFIX="$WORKSPACE/.venv311/bin" "$WORKSPACE/.venv311/bin/python" benchmarks.py interfaces

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,12 +2,16 @@ name: build
 
 on: workflow_dispatch
 
+permissions: {}
+
 env:
   PY_ALL: 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11
 
 jobs:
   wheels:
     name: wheel ${{ matrix.platform || matrix.os }}(${{ matrix.target }}) - ${{ matrix.manylinux || 'auto' }} - ${{ matrix.allocator || 'auto' }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -89,12 +93,14 @@ jobs:
 
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set jemalloc for aarch64 Linux
         if: matrix.target == 'aarch64' && matrix.os == 'ubuntu'
         run: |
           echo "JEMALLOC_SYS_WITH_LG_PAGE=16" >> $GITHUB_ENV
-      - uses: pyo3/maturin-action@v1
+      - uses: pyo3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           rust-toolchain: stable
           command: build
@@ -104,7 +110,7 @@ jobs:
           container: ${{ matrix.container }}
           docker-options: -e CI
       - name: Upload wheels
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist-${{ matrix.platform || matrix.os }}-${{ matrix.target }}-${{ matrix.manylinux || 'auto' }}-${{ matrix.allocator || 'auto' }}
           path: dist

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,21 +6,29 @@ on:
     branches:
       - master
 
+permissions: {}
+
 env:
   UV_PYTHON: 3.13
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-    - uses: actions/checkout@v6
-    - uses: astral-sh/setup-uv@v7
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         enable-cache: false
     - name: Install
+      env:
+        UV_PYTHON: ${{ env.UV_PYTHON }}
       run: |
-        uv python install ${{ env.UV_PYTHON }}
+        uv python install "$UV_PYTHON"
         uv venv .venv
         uv sync --group lint
     - name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,28 +5,36 @@ on:
     tags:
       - v*.*.*
 
+permissions: {}
+
 env:
   PY_ALL: 3.10 3.11 3.12 3.13 3.13t 3.14 3.14t pypy3.11
 
 jobs:
   sdist:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
-    - uses: actions/checkout@v6
-    - uses: pyo3/maturin-action@v1
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: pyo3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
       with:
         rust-toolchain: stable
         command: sdist
         args: --out dist
     - name: Upload sdist
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: dist-sdist
         path: dist
 
   wheels:
     name: wheel ${{ matrix.platform || matrix.os }}(${{ matrix.target }}) - ${{ matrix.manylinux || 'auto' }} - ${{ matrix.allocator || 'auto' }}
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -108,12 +116,14 @@ jobs:
 
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set jemalloc for aarch64 Linux
         if: matrix.target == 'aarch64' && matrix.os == 'ubuntu'
         run: |
           echo "JEMALLOC_SYS_WITH_LG_PAGE=16" >> $GITHUB_ENV
-      - uses: pyo3/maturin-action@v1
+      - uses: pyo3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           rust-toolchain: stable
           command: build
@@ -123,7 +133,7 @@ jobs:
           container: ${{ matrix.container }}
           docker-options: -e CI
       - name: Upload wheels
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist-${{ matrix.platform || matrix.os }}-${{ matrix.target }}-${{ matrix.manylinux || 'auto' }}-${{ matrix.allocator || 'auto' }}
           path: dist
@@ -138,13 +148,13 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: dist-*
           merge-multiple: true
           path: dist
       - name: Publish package to pypi
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           skip-existing: true
           # FIXME: they broke something recently

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,14 @@ on:
     branches:
       - master
 
+permissions: {}
+
 jobs:
   linux:
     name: linux (${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -31,16 +35,21 @@ jobs:
     env:
       UV_PYTHON: ${{ matrix.python-version }}
     steps:
-    - uses: actions/checkout@v6
-    - uses: astral-sh/setup-uv@v7
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         enable-cache: false
     - name: Install
+      env:
+        UV_PYTHON: ${{ matrix.python-version }}
+        ALLOCATOR: ${{ matrix.allocator }}
       run: |
-        uv python install ${{ env.UV_PYTHON }}
+        uv python install "$UV_PYTHON"
         uv venv .venv
         uv sync --group all
-        uv run --no-sync maturin develop --uv --features ${{ matrix.allocator }}
+        uv run --no-sync maturin develop --uv --features "$ALLOCATOR"
     - name: Test
       run: |
         source .venv/bin/activate
@@ -49,6 +58,8 @@ jobs:
   macos:
     name: macos (${{ matrix.python-version }})
     runs-on: macos-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -66,16 +77,21 @@ jobs:
     env:
       UV_PYTHON: ${{ matrix.python-version }}
     steps:
-    - uses: actions/checkout@v6
-    - uses: astral-sh/setup-uv@v7
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         enable-cache: false
     - name: Install
+      env:
+        UV_PYTHON: ${{ matrix.python-version }}
+        ALLOCATOR: ${{ matrix.allocator }}
       run: |
-        uv python install ${{ env.UV_PYTHON }}
+        uv python install "$UV_PYTHON"
         uv venv .venv
         uv sync --group all
-        uv run --no-sync maturin develop --uv --features ${{ matrix.allocator }}
+        uv run --no-sync maturin develop --uv --features "$ALLOCATOR"
     - name: Test
       run: |
         source .venv/bin/activate
@@ -83,6 +99,8 @@ jobs:
 
   windows:
     runs-on: windows-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -97,13 +115,17 @@ jobs:
     env:
       UV_PYTHON: ${{ matrix.python-version }}
     steps:
-    - uses: actions/checkout@v6
-    - uses: astral-sh/setup-uv@v7
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
       with:
         enable-cache: false
     - name: Install
+      env:
+        UV_PYTHON: ${{ matrix.python-version }}
       run: |
-        uv python install ${{ env.UV_PYTHON }}
+        uv python install "$UV_PYTHON"
         uv venv .venv
         uv sync --group all
         uv run --no-sync maturin develop --uv --features mimalloc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,11 @@ repos:
   - id: trailing-whitespace
   - id: check-added-large-files
 
+- repo: https://github.com/zizmorcore/zizmor-pre-commit
+  rev: v1.25.2
+  hooks:
+  - id: zizmor
+
 - repo: local
   hooks:
   - id: lint-python


### PR DESCRIPTION
## Summary

- Add the [`zizmor`](https://github.com/zizmorcore/zizmor) GitHub Actions security auditor to `.pre-commit-config.yaml`.
- Resolve all 118 findings zizmor reports against the current workflows so the hook passes cleanly:
  - Pin every action to a commit SHA (with a version comment) - addresses `unpinned-uses`.
  - Add a workflow-level `permissions: {}` and per-job least-privilege `permissions:` blocks - addresses `excessive-permissions`.
  - Set `persist-credentials: false` on all `actions/checkout` calls - addresses `artipacked`.
  - Pass `${{ matrix.* }}`, `${{ env.* }}`, and `${{ github.workspace }}` values via `env:` and quote them as shell variables in `run:` blocks - addresses `template-injection`.
  - Replace the archived `actions-rs/toolchain@v1` with an inline `rustup` script step in `benchmarks.yml` - addresses `archived-uses` and `superfluous-actions`.
- Add `cooldown.default-days: 7` to both Dependabot ecosystems to satisfy the `dependabot-cooldown` audit.

After these changes, `pre-commit run zizmor --all-files` reports `No findings to report. Good job!`.

## Test plan

- [x] `zizmor .github/workflows/` exits 0 with no findings.
- [x] `pre-commit run zizmor --all-files` passes.
- [ ] CI workflows still run successfully on this PR (test/lint).

## AI Disclaimer

This PR was developed with the assistance of either Claude or Codex. I've reviewed and verified the changes.