### PR TITLE
chore(logging): use concise, professional copy

### DIFF
--- a/granian/server/common.py
+++ b/granian/server/common.py
@@ -499,7 +499,7 @@ class AbstractServer(Generic[WT]):
         self._call_hooks(self.hooks_shutdown)
         self._unlink_pidfile()
 
-        logger.info('Granian shutdown completed, see ya!')
+        logger.info('Granian shutdown completed.')
 
         if not exit_code and self.interrupt_children:
             exit_code = 1


### PR DESCRIPTION
Informal language or jokes stop being fun after a day, week, or month of work and turn into clutter. Concise, formal language is the best default.