### PR TITLE
Add request latency histogram metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@ Granian exposes the following runtime metrics in Prometheus format. All the metr
 | `connections_handled` | counter | absolute number | worker | Number of accepted connections |
 | `connections_err` | gauge | absolute number | worker | Number of failed connections |
 | `requests_handled` | counter | absolute number | worker | Number of processed requests |
+| `request_duration_seconds` | histogram | seconds | worker | Distribution of end-to-end application request durations (until the full response body is sent); static file requests are excluded |
 | `static_requests_handled` | counter | absolute number | worker | Number of processed requests for static files |
 | `static_requests_err` | counter | absolute number | worker | Number of requests for static files resulted in a non 200 response code |
 | `blocking_threads` | gauge | absolute number | worker | Current number of blocking threads in the pool (on async protocols this is always 1) |

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,18 +1,35 @@
+use std::pin::Pin;
 use std::sync::{Arc, Mutex, atomic};
+use std::task::{Context, Poll};
 
+use http_body_util::BodyExt;
 use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[cfg(not(Py_GIL_DISABLED))]
 use crate::ipc;
+use crate::http::{HTTPResponse, HTTPResponseBody};
 use crate::runtime;
 
 pub(crate) type MetricsData = Vec<MetricValue>;
+
+// OTel `http.server.request.duration` buckets, as integer microseconds.
+pub(crate) const DURATION_BUCKETS_US: [u64; 14] = [
+    5_000, 10_000, 25_000, 50_000, 75_000, 100_000, 250_000, 500_000, 750_000, 1_000_000, 2_500_000, 5_000_000,
+    7_500_000, 10_000_000,
+];
+
+// `le` labels (seconds) for `DURATION_BUCKETS_US`, pre-rendered to avoid float casts.
+const DURATION_BUCKETS_LE: [&str; 14] = [
+    "0.005", "0.01", "0.025", "0.05", "0.075", "0.1", "0.25", "0.5", "0.75", "1", "2.5", "5", "7.5", "10",
+];
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) enum MetricValue {
     Abs(usize),
     Int(isize),
+    // Non-cumulative per-bucket counts, total observations and sum (microseconds).
+    Hist { buckets: Vec<u64>, count: u64, sum_us: u64 },
 }
 
 impl std::fmt::Display for MetricValue {
@@ -20,8 +37,108 @@ impl std::fmt::Display for MetricValue {
         match self {
             Self::Abs(v) => v.fmt(f),
             Self::Int(v) => v.fmt(f),
+            Self::Hist { count, .. } => count.fmt(f),
         }
     }
+}
+
+pub(crate) struct DurationHistogram {
+    buckets: [atomic::AtomicU64; DURATION_BUCKETS_US.len()],
+    count: atomic::AtomicU64,
+    sum_us: atomic::AtomicU64,
+}
+
+impl DurationHistogram {
+    fn new() -> Self {
+        Self {
+            buckets: std::array::from_fn(|_| atomic::AtomicU64::new(0)),
+            count: 0.into(),
+            sum_us: 0.into(),
+        }
+    }
+
+    #[inline(always)]
+    pub fn observe(&self, micros: u64) {
+        for (idx, edge) in DURATION_BUCKETS_US.iter().enumerate() {
+            if micros <= *edge {
+                self.buckets[idx].fetch_add(1, atomic::Ordering::Relaxed);
+                break;
+            }
+        }
+        self.count.fetch_add(1, atomic::Ordering::Relaxed);
+        self.sum_us.fetch_add(micros, atomic::Ordering::Relaxed);
+    }
+
+    fn snapshot(&self) -> MetricValue {
+        MetricValue::Hist {
+            buckets: self.buckets.iter().map(|v| v.load(atomic::Ordering::Relaxed)).collect(),
+            count: self.count.load(atomic::Ordering::Relaxed),
+            sum_us: self.sum_us.load(atomic::Ordering::Relaxed),
+        }
+    }
+}
+
+pin_project_lite::pin_project! {
+    // Wraps a response body to record request duration once the body has been
+    // fully sent (or on drop, e.g. a client disconnecting mid-stream). This
+    // captures true end-to-end time, including streaming body transmission.
+    struct TimedBody {
+        #[pin]
+        inner: HTTPResponseBody,
+        start: std::time::Instant,
+        metrics: ArcWorkerMetrics,
+        done: bool,
+    }
+    impl PinnedDrop for TimedBody {
+        fn drop(this: Pin<&mut Self>) {
+            let this = this.project();
+            if !*this.done {
+                this.metrics.request_duration.observe(this.start.elapsed().as_micros() as u64);
+            }
+        }
+    }
+}
+
+impl hyper::body::Body for TimedBody {
+    type Data = hyper::body::Bytes;
+    type Error = anyhow::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<hyper::body::Frame<Self::Data>, Self::Error>>> {
+        let this = self.project();
+        let out = this.inner.poll_frame(cx);
+        if matches!(out, Poll::Ready(None)) && !*this.done {
+            *this.done = true;
+            this.metrics.request_duration.observe(this.start.elapsed().as_micros() as u64);
+        }
+        out
+    }
+
+    fn is_end_stream(&self) -> bool {
+        self.inner.is_end_stream()
+    }
+
+    fn size_hint(&self) -> hyper::body::SizeHint {
+        self.inner.size_hint()
+    }
+}
+
+// Wrap `response` so its duration is recorded when the body finishes streaming.
+pub(crate) fn timed_response(
+    response: HTTPResponse,
+    start: std::time::Instant,
+    metrics: ArcWorkerMetrics,
+) -> HTTPResponse {
+    let (parts, inner) = response.into_parts();
+    let body = TimedBody {
+        inner,
+        start,
+        metrics,
+        done: false,
+    };
+    HTTPResponse::from_parts(parts, body.boxed())
 }
 
 struct MainMetrics {
@@ -43,6 +160,7 @@ pub(crate) struct WorkerMetrics {
     pub blocking_idle_cumul: atomic::AtomicUsize,
     pub blocking_busy_cumul: atomic::AtomicUsize,
     pub py_wait_cumul: atomic::AtomicUsize,
+    pub request_duration: DurationHistogram,
 }
 
 impl MainMetrics {
@@ -70,6 +188,7 @@ impl WorkerMetrics {
             blocking_idle_cumul: 0.into(),
             blocking_busy_cumul: 0.into(),
             py_wait_cumul: 0.into(),
+            request_duration: DurationHistogram::new(),
         }
     }
 }
@@ -141,6 +260,37 @@ impl MetricsAggregator {
         for items in &mut wrk {
             all.append(items);
         }
+
+        // Request duration histogram (last entry in `MetricsData`).
+        let hist_idx = wrk_metrics.len();
+        let hist_label = format!("{prefix}request_duration_seconds");
+        let mut hist_lines: Vec<String> = vec![format!("# TYPE {hist_label} histogram")];
+        {
+            let wrk_data = self.data_w.lock().unwrap();
+            for (idx, values) in wrk_data.iter().enumerate() {
+                if let Some(MetricValue::Hist { buckets, count, sum_us }) = values.get(hist_idx) {
+                    let worker = idx + 1;
+                    let mut cumulative: u64 = 0;
+                    for (bucket_idx, le) in DURATION_BUCKETS_LE.iter().enumerate() {
+                        cumulative += buckets.get(bucket_idx).copied().unwrap_or(0);
+                        hist_lines.push(format!(
+                            "{hist_label}_bucket{{worker=\"{worker}\",le=\"{le}\"}} {cumulative}"
+                        ));
+                    }
+                    hist_lines.push(format!(
+                        "{hist_label}_bucket{{worker=\"{worker}\",le=\"+Inf\"}} {count}"
+                    ));
+                    hist_lines.push(format!(
+                        "{hist_label}_sum{{worker=\"{worker}\"}} {}.{:06}",
+                        sum_us / 1_000_000,
+                        sum_us % 1_000_000
+                    ));
+                    hist_lines.push(format!("{hist_label}_count{{worker=\"{worker}\"}} {count}"));
+                }
+            }
+        }
+        all.append(&mut hist_lines);
+
         all.join("\n")
     }
 }
@@ -246,6 +396,8 @@ fn collect_metrics(birth: &std::time::Instant, data: &Arc<WorkerMetrics>) -> Met
         MetricValue::Abs(data.blocking_idle_cumul.load(atomic::Ordering::Acquire)),
         MetricValue::Abs(data.blocking_busy_cumul.load(atomic::Ordering::Acquire)),
         MetricValue::Abs(data.py_wait_cumul.load(atomic::Ordering::Acquire)),
+        // Keep last: `format_metrics` reads the histogram positionally.
+        data.request_duration.snapshot(),
     ]
 }
 

--- a/src/workers.rs
+++ b/src/workers.rs
@@ -350,6 +350,28 @@ macro_rules! service_proto_fut {
     }};
 }
 
+// As `service_proto_fut!`, but records end-to-end request duration: the timer
+// runs until the full response body has been sent (see `metrics::timed_response`).
+macro_rules! service_proto_fut_timed {
+    ($proto:expr, $self:expr, $req:expr) => {{
+        let fut = ($self.f)(
+            $self.rt.clone(),
+            $self.disconnect_guard.clone(),
+            $self.ctx.callback.clone(),
+            $self.addr_local.clone(),
+            $self.addr_remote.clone(),
+            $req,
+            $proto,
+        );
+        let metrics = $self.ctx.metrics.clone();
+        let start = std::time::Instant::now();
+        Box::pin(async move {
+            let res = fut.await;
+            Ok::<_, hyper::Error>(crate::metrics::timed_response(res, start, metrics))
+        })
+    }};
+}
+
 macro_rules! service_impl {
     ($proto_marker:ty, $proto:expr) => {
         impl<F, Ret> hyper::service::Service<crate::http::HTTPRequest>
@@ -447,7 +469,7 @@ macro_rules! service_impl {
                     .metrics
                     .req_handled
                     .fetch_add(1, std::sync::atomic::Ordering::Release);
-                service_proto_fut!($proto, self, req)
+                service_proto_fut_timed!($proto, self, req)
             }
         }
 
@@ -501,7 +523,7 @@ macro_rules! service_impl {
                     });
                 }
 
-                service_proto_fut!($proto, self, req)
+                service_proto_fut_timed!($proto, self, req)
             }
         }
     };

--- a/tests/apps/asgi.py
+++ b/tests/apps/asgi.py
@@ -66,6 +66,15 @@ async def pathsend(scope, receive, send):
     await send({'type': 'http.response.pathsend', 'path': str(path)})
 
 
+async def stream_slow(scope, receive, send):
+    # Streaming response with a delay between the first and last body chunk, so
+    # time-to-first-byte is tiny but end-to-end duration is measurable (~0.3s).
+    await send(PLAINTEXT_RESPONSE)
+    await send({'type': 'http.response.body', 'body': b'first', 'more_body': True})
+    await asyncio.sleep(0.3)
+    await send({'type': 'http.response.body', 'body': b'last', 'more_body': False})
+
+
 async def ws_reject(scope, receive, send):
     return
 
@@ -221,6 +230,7 @@ def app(scope, receive, send):
         '/sniffio': sniff_aio_impl,
         '/echo': echo,
         '/file': pathsend,
+        '/stream_slow': stream_slow,
         '/ws_reject': ws_reject,
         '/ws_rejecte': ws_reject_explicit,
         '/ws_rejectc': ws_reject_custom,

--- a/tests/apps/rsgi.py
+++ b/tests/apps/rsgi.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import pathlib
@@ -40,6 +41,15 @@ async def stream(_, protocol: HTTPProtocol):
     trx = protocol.response_stream(200, [('content-type', 'text/plain; charset=utf-8')])
     for _ in range(0, 3):
         await trx.send_bytes(b'test')
+
+
+async def stream_slow(_, protocol: HTTPProtocol):
+    # Streaming response with a delay between chunks, so time-to-first-byte is
+    # tiny but end-to-end duration is measurable (~0.3s).
+    trx = protocol.response_stream(200, [('content-type', 'text/plain; charset=utf-8')])
+    await trx.send_bytes(b'first')
+    await asyncio.sleep(0.3)
+    await trx.send_bytes(b'last')
 
 
 async def file(scope: Scope, protocol: HTTPProtocol):
@@ -137,6 +147,7 @@ def app(scope, protocol):
         '/file': file,
         '/file_range': file_range,
         '/stream': stream,
+        '/stream_slow': stream_slow,
         '/ws_reject': ws_reject,
         '/ws_info': ws_info,
         '/ws_echo': ws_echo,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ async def _server(
     task_impl='asyncio',
     static_mount=False,
     static_rewrite=False,
+    metrics_port=None,
 ):
     certs_path = Path.cwd() / 'tests' / 'fixtures' / 'tls'
     kwargs = {
@@ -37,6 +38,11 @@ async def _server(
         'task_impl': task_impl,
         'websockets': ws,
     }
+    if metrics_port is not None:
+        kwargs['metrics_enabled'] = True
+        kwargs['metrics_address'] = '127.0.0.1'
+        kwargs['metrics_port'] = metrics_port
+        kwargs['metrics_scrape_interval'] = 1
     if tls:
         if tls == 'private':
             kwargs['ssl_cert'] = certs_path / 'pcert.pem'
@@ -103,6 +109,14 @@ def server_port():
 
 
 @pytest.fixture(scope='function')
+def metrics_port():
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as sock:
+        sock.bind(('localhost', 0))
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        return sock.getsockname()[1]
+
+
+@pytest.fixture(scope='function')
 def asgi_server(server_port, **extras):
     return partial(_server, 'asgi', server_port, **extras)
 
@@ -130,3 +144,13 @@ def server_tls(server_port, request, tls=True, **extras):
 @pytest.fixture(scope='function')
 def server_static_files(server_port, request, static_mount=True, **extras):
     return partial(_server, request.param, server_port, static_mount=static_mount, **extras)
+
+
+@pytest.fixture(scope='function')
+def server_metrics(server_port, metrics_port, request):
+    return metrics_port, partial(_server, request.param, server_port, metrics_port=metrics_port)
+
+
+@pytest.fixture(scope='function')
+def server_metrics_static(server_port, metrics_port, request):
+    return metrics_port, partial(_server, request.param, server_port, metrics_port=metrics_port, static_mount=True)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,201 @@
+import asyncio
+import re
+
+import httpx
+import pytest
+
+
+N_REQUESTS = 10
+
+HIST = 'granian_request_duration_seconds'
+# Bucket upper bounds (seconds), plus `+Inf`.
+EXPECTED_LE = [
+    '0.005',
+    '0.01',
+    '0.025',
+    '0.05',
+    '0.075',
+    '0.1',
+    '0.25',
+    '0.5',
+    '0.75',
+    '1',
+    '2.5',
+    '5',
+    '7.5',
+    '10',
+    '+Inf',
+]
+
+_SAMPLE_RE = re.compile(r'^(?P<name>[^{\s]+)(?:\{(?P<labels>[^}]*)\})?\s+(?P<value>\S+)$')
+_LABEL_RE = re.compile(r'(\w+)="([^"]*)"')
+
+
+def _parse_metrics(text):
+    """Parse Prometheus text exposition into {metric_name: [(labels_dict, value), ...]}."""
+    out = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        match = _SAMPLE_RE.match(line)
+        labels = dict(_LABEL_RE.findall(match['labels'])) if match['labels'] else {}
+        out.setdefault(match['name'], []).append((labels, float(match['value'])))
+    return out
+
+
+def _series_sum(metrics, name):
+    """Sum every sample for `name`, across worker labels."""
+    return sum(v for _, v in metrics.get(name, []))
+
+
+def _hist_count(metrics):
+    return _series_sum(metrics, f'{HIST}_count')
+
+
+def _hist_bucket_inf(metrics):
+    """Sum of the `+Inf` bucket across workers."""
+    return sum(v for labels, v in metrics.get(f'{HIST}_bucket', []) if labels.get('le') == '+Inf')
+
+
+async def _scrape(metrics_port):
+    async with httpx.AsyncClient() as client:
+        res = await client.get(f'http://127.0.0.1:{metrics_port}/', timeout=2)
+    return res.text
+
+
+async def _wait_for(metrics_port, predicate, timeout=20):
+    """Scrape until `predicate(parsed_metrics)` holds (or timeout), return last body."""
+    deadline = asyncio.get_running_loop().time() + timeout
+    text = ''
+    while asyncio.get_running_loop().time() < deadline:
+        try:
+            text = await _scrape(metrics_port)
+        except Exception:
+            await asyncio.sleep(0.5)
+            continue
+        if predicate(_parse_metrics(text)):
+            return text
+        await asyncio.sleep(0.5)
+    return text
+
+
+async def _wait_for_count(metrics_port, expected, timeout=20):
+    return await _wait_for(metrics_port, lambda m: _hist_count(m) >= expected, timeout)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('server_metrics', ['asgi', 'rsgi', 'wsgi'], indirect=True)
+@pytest.mark.parametrize('runtime_mode', ['mt', 'st'])
+async def test_request_latency_histogram(server_metrics, runtime_mode):
+    metrics_port, server = server_metrics
+
+    async with server(runtime_mode, ws=False) as port:
+        for _ in range(N_REQUESTS):
+            res = httpx.get(f'http://localhost:{port}/info')
+            assert res.status_code == 200
+
+        text = await _wait_for_count(metrics_port, N_REQUESTS)
+
+    metrics = _parse_metrics(text)
+
+    assert f'{HIST}_bucket' in metrics
+    assert f'{HIST}_sum' in metrics
+    assert f'{HIST}_count' in metrics
+    assert f'# TYPE {HIST} histogram' in text
+
+    assert _hist_count(metrics) == N_REQUESTS
+    assert _hist_bucket_inf(metrics) == N_REQUESTS
+    assert _series_sum(metrics, f'{HIST}_sum') > 0.0
+    # No static files mounted, so every request is dynamic.
+    assert _series_sum(metrics, 'granian_requests_handled') == N_REQUESTS
+
+    workers = {labels['worker'] for labels, _ in metrics[f'{HIST}_bucket']}
+    assert workers
+
+    for worker in workers:
+        buckets = [(labels['le'], v) for labels, v in metrics[f'{HIST}_bucket'] if labels['worker'] == worker]
+        by_le = dict(buckets)
+
+        # Every bucket boundary present exactly once.
+        assert sorted(by_le.keys(), key=lambda le: float('inf') if le == '+Inf' else float(le)) == EXPECTED_LE
+
+        # Cumulative buckets are monotonically non-decreasing.
+        ordered = [by_le[le] for le in EXPECTED_LE]
+        assert all(ordered[i] <= ordered[i + 1] for i in range(len(ordered) - 1))
+
+        count = next(v for labels, v in metrics[f'{HIST}_count'] if labels['worker'] == worker)
+        assert by_le['+Inf'] == count
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('server_metrics_static', ['asgi', 'rsgi', 'wsgi'], indirect=True)
+@pytest.mark.parametrize('runtime_mode', ['st'])
+async def test_request_latency_histogram_excludes_static(server_metrics_static, runtime_mode):
+    metrics_port, server = server_metrics_static
+
+    async with server(runtime_mode, ws=False) as port:
+        # One dynamic request (recorded) + several static ones (excluded).
+        assert httpx.get(f'http://localhost:{port}/info').status_code == 200
+        for _ in range(3):
+            assert httpx.get(f'http://localhost:{port}/static/media.png').status_code == 200
+
+        # Wait until both the dynamic and static requests are reflected.
+        text = await _wait_for(
+            metrics_port,
+            lambda m: _hist_count(m) >= 1 and _series_sum(m, 'granian_static_requests_handled') >= 3,
+        )
+
+    metrics = _parse_metrics(text)
+
+    # Only the dynamic request contributes to the histogram; static requests
+    # are counted by their dedicated counters instead.
+    assert _hist_count(metrics) == 1
+    assert _hist_bucket_inf(metrics) == 1
+    assert _series_sum(metrics, 'granian_static_requests_handled') == 3
+    assert _series_sum(metrics, 'granian_requests_handled') == 4
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('server_metrics', ['asgi', 'rsgi'], indirect=True)
+@pytest.mark.parametrize('runtime_mode', ['st'])
+async def test_request_latency_histogram_streaming_e2e(server_metrics, runtime_mode):
+    metrics_port, server = server_metrics
+
+    async with server(runtime_mode, ws=False) as port:
+        # `/stream_slow` sends its body over ~0.3s. The recorded duration must
+        # reflect the full send time, not time-to-first-byte.
+        res = httpx.get(f'http://localhost:{port}/stream_slow')
+        assert res.status_code == 200
+        assert res.text == 'firstlast'
+
+        text = await _wait_for_count(metrics_port, 1)
+
+    metrics = _parse_metrics(text)
+
+    assert _hist_count(metrics) == 1
+    assert _hist_bucket_inf(metrics) == 1
+    # The observation lands above the 0.1s boundary: proof of end-to-end timing.
+    # A time-to-first-byte measurement would fall into a near-zero bucket.
+    below_100ms = sum(v for labels, v in metrics[f'{HIST}_bucket'] if labels.get('le') == '0.1')
+    assert below_100ms == 0
+    assert _series_sum(metrics, f'{HIST}_sum') >= 0.25
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('server_metrics', ['asgi'], indirect=True)
+@pytest.mark.parametrize('runtime_mode', ['st'])
+async def test_request_latency_histogram_empty(server_metrics, runtime_mode):
+    metrics_port, server = server_metrics
+
+    async with server(runtime_mode, ws=False):
+        # At least one scrape cycle without issuing requests.
+        await asyncio.sleep(2)
+        text = await _scrape(metrics_port)
+
+    metrics = _parse_metrics(text)
+
+    # Histogram is present with a zero count when nothing was observed.
+    assert f'# TYPE {HIST} histogram' in text
+    assert _hist_count(metrics) == 0
+    assert _hist_bucket_inf(metrics) == 0


### PR DESCRIPTION
Solves #871 

Note: AI implemented. I'm not familiar with Rust. I've reviewed the code. I apologize if this is seen as too much AI slop :)

Expose granian_request_duration_seconds, a per-worker Prometheus histogram of application request durations. Static-file requests are excluded.

Adds a LatencyHistogram to WorkerMetrics, a MetricValue::Hist variant for IPC transport, histogram exposition in the aggregator, and integration tests covering exposition, counts, static exclusion and the empty case.

Co-authored-by: GitHub Copilot <copilot@github.com>