### PR TITLE
Release the GIL while dropping the runtime on worker shutdown

### DIFF
--- a/src/serve.rs
+++ b/src/serve.rs
@@ -94,7 +94,7 @@ macro_rules! serve_fn {
                 Ok(())
             });
 
-            drop(rt);
+            py.detach(|| drop(rt));
 
             if let Err(err) = main_loop {
                 log::error!("{err}");
@@ -227,7 +227,7 @@ macro_rules! serve_fn {
                 Ok(())
             });
 
-            drop(rtm);
+            event_loop.py().detach(|| drop(rtm));
 
             if let Err(err) = main_loop {
                 log::error!("{err}");

--- a/tests/apps/asgi.py
+++ b/tests/apps/asgi.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import pathlib
+import time
 
 import sniffio
 
@@ -206,6 +207,28 @@ async def timeout_w(scope, receive, send):
     await send({'type': 'http.response.body', 'body': ret, 'more_body': False})
 
 
+async def shutdown_race(scope, receive, send):
+    loop = asyncio.get_running_loop()
+    if not hasattr(loop, '_test_busy_task'):
+
+        async def keep_loop_busy():
+            while True:
+                await asyncio.sleep(0)
+
+        loop._test_busy_task = loop.create_task(keep_loop_busy())
+
+        inner_write = loop._write_to_self
+
+        def slow_write_to_self():
+            time.sleep(0.2)
+            inner_write()
+
+        loop._write_to_self = slow_write_to_self
+
+    await send(PLAINTEXT_RESPONSE)
+    await send({'type': 'http.response.body', 'body': b'ok', 'more_body': False})
+
+
 async def lifespan(scope, receive, send):
     msg = await receive()
     if msg['type'] == 'lifespan.startup':
@@ -233,4 +256,5 @@ def app(scope, receive, send):
         '/err_proto/flow': err_proto_flow,
         '/timeout_n': timeout_n,
         '/timeout_w': timeout_w,
+        '/shutdown_race': shutdown_race,
     }.get(scope['path'], info)(scope, receive, send)

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -1,0 +1,56 @@
+import multiprocessing as mp
+import os
+import signal
+import socket
+import sys
+import time
+
+import httpx
+import pytest
+
+from granian import Granian
+
+
+def _serve(**kwargs):
+    server = Granian('tests.apps.asgi:app', **kwargs)
+    server.serve()
+
+
+def _spawn_server(port, runtime_mode):
+    kwargs = {
+        'interface': 'asgi',
+        'port': port,
+        'loop': 'asyncio',
+        'blocking_threads': 1,
+        'runtime_mode': runtime_mode,
+        'workers': 1,
+    }
+    proc = mp.get_context('spawn').Process(target=_serve, kwargs=kwargs)
+    proc.start()
+    for _ in range(30):
+        try:
+            sock = socket.create_connection(('127.0.0.1', port), timeout=1)
+            sock.close()
+            return proc
+        except OSError:
+            time.sleep(0.5)
+    proc.kill()
+    raise RuntimeError('Cannot bind server')
+
+
+@pytest.mark.skipif(bool(os.getenv('PGO_RUN')), reason='PGO build')
+@pytest.mark.skipif(sys.platform == 'win32', reason='requires SIGTERM')
+@pytest.mark.parametrize('runtime_mode', ['mt', 'st'])
+def test_sigterm_shutdown_busy_loop(server_port, runtime_mode):
+    proc = _spawn_server(server_port, runtime_mode)
+    try:
+        res = httpx.get(f'http://localhost:{server_port}/shutdown_race')
+        assert res.status_code == 200
+
+        os.kill(proc.pid, signal.SIGTERM)
+        proc.join(timeout=10)
+        assert not proc.is_alive(), 'worker deadlocked during shutdown'
+    finally:
+        if proc.is_alive():
+            proc.kill()
+            proc.join(timeout=5)


### PR DESCRIPTION
Closes #875.

## What this does

On worker shutdown the main thread dropped the tokio runtime while holding the GIL. Dropping the runtime joins its threads, and at that moment one of them can be blocked waiting for that same GIL inside `loop.call_soon_threadsafe(...)` (the `run_until_complete` waker) - both threads then wait on each other forever and the worker never exits. The full race analysis and the production impact are in #875.

The change releases the GIL for the duration of the drop, in both `serve_fn` variants:

- mt: `drop(rt);` -> `py.detach(|| drop(rt));`
- st: `drop(rtm);` -> `event_loop.py().detach(|| drop(rtm));`

## Changed files

- `src/serve.rs` - the fix itself
- `tests/apps/asgi.py` - a route that recreates the shutdown race conditions: a task keeping the loop busy plus a wider GIL-release window inside `_write_to_self` (see #875 for why this makes the hang fire on every run)
- `tests/test_shutdown.py` - the regression test: starts a server, hits that route, sends SIGTERM and requires the process to exit within 10 seconds. On current master it fails with both `runtime_mode` values (the worker hangs forever), with the patch it passes.

## Heads-up: the worker stop now ends with a #846 panic

With the hang gone, worker shutdown runs further and hits the panic family from #846 (`Cannot drop pointer into Python heap without the thread being attached`; the build sets `pyo3_disable_reference_pool`): the runtime is now dropped by a detached thread, so `Py` references freed during that drop panic instead of decref'ing. You can see it right in the output of the regression test, in both `runtime_mode` runs: the backtrace points at the event loop reference held by `RuntimeWrapper` - its last `Arc<Py<PyAny>>` clone is dropped inside the detached `drop(rt)`. Under real traffic we also saw a second source: `Py` refs owned by still-pending tasks (eg a websocket `send()` stuck towards a client that stopped reading). Both are described in the "Related observation" section of #875.

The impact is limited to the very end of worker stop, after the worker has already stopped serving and the shutdown has finished its work: the process exits through an abort instead of a clean exit, with the panic message in the log. The test still passes - it only requires the process to exit, and the master completes the shutdown normally (`Stopped worker-1`). I kept this PR minimal on purpose.
