### PR TITLE
Prevent process environment from overriding WSGI request data

### DIFF
--- a/granian/wsgi.py
+++ b/granian/wsgi.py
@@ -50,7 +50,7 @@ def _callback_wrapper(callback: Callable[..., Any], scope_opts: dict[str, Any], 
         resp = Response()
         environ = basic_env | scope
         if environ['SCRIPT_NAME']:
-            environ['PATH_INFO'] = environ['PATH_INFO'][len(environ['SCRIPT_NAME']) :] or '/'
+            environ['PATH_INFO'] = scope['PATH_INFO'] = environ['PATH_INFO'][len(environ['SCRIPT_NAME']) :] or '/'
 
         rv = callback(environ, resp)
 

--- a/granian/wsgi.py
+++ b/granian/wsgi.py
@@ -48,11 +48,11 @@ def _callback_wrapper(callback: Callable[..., Any], scope_opts: dict[str, Any], 
 
     def _runner(proto, scope):
         resp = Response()
-        scope.update(basic_env)
-        if scope['SCRIPT_NAME']:
-            scope['PATH_INFO'] = scope['PATH_INFO'][len(scope['SCRIPT_NAME']) :] or '/'
+        environ = basic_env | scope
+        if environ['SCRIPT_NAME']:
+            environ['PATH_INFO'] = environ['PATH_INFO'][len(environ['SCRIPT_NAME']) :] or '/'
 
-        rv = callback(scope, resp)
+        rv = callback(environ, resp)
 
         if isinstance(rv, list):
             proto.response_bytes(resp.status, resp.headers, b''.join(rv))

--- a/granian/wsgi.py
+++ b/granian/wsgi.py
@@ -49,8 +49,8 @@ def _callback_wrapper(callback: Callable[..., Any], scope_opts: dict[str, Any], 
     def _runner(proto, scope):
         resp = Response()
         environ = basic_env | scope
-        if environ['SCRIPT_NAME']:
-            environ['PATH_INFO'] = scope['PATH_INFO'] = environ['PATH_INFO'][len(environ['SCRIPT_NAME']) :] or '/'
+        if basic_env['SCRIPT_NAME']:
+            environ['PATH_INFO'] = scope['PATH_INFO'][len(basic_env['SCRIPT_NAME']) :] or '/'
 
         rv = callback(environ, resp)
 

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -28,22 +28,6 @@ async def test_scope(wsgi_server, runtime_mode):
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(bool(os.getenv('PGO_RUN')), reason='PGO build')
-@pytest.mark.parametrize('runtime_mode', ['mt', 'st'])
-async def test_scope_not_overridden_by_process_env(wsgi_server, runtime_mode, monkeypatch):
-    monkeypatch.setenv('HTTP_X_CUSTOM', 'env_value')
-    monkeypatch.setenv('HTTP_HOST', 'env.example')
-    async with wsgi_server(runtime_mode) as port:
-        res = httpx.get(f'http://localhost:{port}/info', headers=[('x-custom', 'header_value')])
-
-    assert res.status_code == 200
-
-    data = res.json()
-    assert data['headers']['HTTP_X_CUSTOM'] == 'header_value'
-    assert data['headers']['HTTP_HOST'] == f'localhost:{port}'
-
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize('runtime_mode', ['mt', 'st'])
 async def test_body(wsgi_server, runtime_mode):
     async with wsgi_server(runtime_mode) as port:

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -28,6 +28,22 @@ async def test_scope(wsgi_server, runtime_mode):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(bool(os.getenv('PGO_RUN')), reason='PGO build')
+@pytest.mark.parametrize('runtime_mode', ['mt', 'st'])
+async def test_scope_not_overridden_by_process_env(wsgi_server, runtime_mode, monkeypatch):
+    monkeypatch.setenv('HTTP_X_CUSTOM', 'env_value')
+    monkeypatch.setenv('HTTP_HOST', 'env.example')
+    async with wsgi_server(runtime_mode) as port:
+        res = httpx.get(f'http://localhost:{port}/info', headers=[('x-custom', 'header_value')])
+
+    assert res.status_code == 200
+
+    data = res.json()
+    assert data['headers']['HTTP_X_CUSTOM'] == 'header_value'
+    assert data['headers']['HTTP_HOST'] == f'localhost:{port}'
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize('runtime_mode', ['mt', 'st'])
 async def test_body(wsgi_server, runtime_mode):
     async with wsgi_server(runtime_mode) as port:


### PR DESCRIPTION
Fixes #878.

## What

In the WSGI interface, `_runner` applied `os.environ` on top of the request scope (`scope.update(basic_env)`), so any process environment variable named like a CGI key (`HTTP_HOST`, `HTTP_AUTHORIZATION`, `REQUEST_METHOD`, ...) silently replaced the corresponding request value on every request.

This PR builds the per-request environ with the environment as the base and request data on top of it (`basic_env | scope`), matching the `wsgiref` precedence (`WSGIServer.setup_environ` + `BaseHandler`).

## Why it matters

Environment variables named `HTTP_*` are not exotic - e.g. a k8s pod with an `HTTP_HOST` env var (a common "public base URL" pattern) breaks the `Host` header of every request, and an `HTTP_AUTHORIZATION` / `HTTP_X_FORWARDED_FOR` env var would silently spoof auth / client IP.

## Notes

- Keys Granian sets itself (`wsgi.*`, `GATEWAY_INTERFACE`, `SERVER_SOFTWARE`, `SCRIPT_NAME`) are absent from the request scope, so they are applied exactly as before.
- The request scope dict is no longer mutated in place; with `url_path_prefix` set, the access log now reports the path as received (prefix included) rather than the stripped one. Happy to preserve the old logging behavior instead if you prefer.
- Performance: microbenchmark of the merge shows `basic_env | scope` at parity with the old `scope.update(basic_env)` for small environments and faster for large ones (it avoids re-inserting the environment into the request dict); an interleaved wrk A/B run (hello-world app, 1 worker) shows no throughput difference beyond noise.
- Test: request header vs. same-named env var - the header must win (fails on master, passes with the fix).
