### PR TITLE
Fix memory spikes in streamed WSGI/ASGI/RSGI responses

### DIFF
--- a/src/asgi/io.rs
+++ b/src/asgi/io.rs
@@ -23,7 +23,7 @@ use super::{
 };
 use crate::{
     conversion::FutureResultToPy,
-    http::{HTTPResponse, HTTPResponseBody, HV_SERVER, response_404},
+    http::{HTTPResponse, HTTPResponseBody, HV_SERVER, body_stream_channel, response_404},
     runtime::{
         Runtime, RuntimeRef, done_future_into_py, empty_future_into_py, err_future_into_py, future_into_py_futlike,
     },
@@ -43,7 +43,7 @@ pub(crate) struct ASGIHTTPProtocol {
     response_started: atomic::AtomicBool,
     response_chunked: atomic::AtomicBool,
     response_intent: Mutex<Option<(u16, HeaderMap)>>,
-    body_tx: Mutex<Option<mpsc::UnboundedSender<body::Bytes>>>,
+    body_tx: Mutex<Option<mpsc::Sender<body::Bytes>>>,
     flow_rx_exhausted: Arc<atomic::AtomicBool>,
     flow_rx_closed: Arc<atomic::AtomicBool>,
     flow_tx_waiter: Arc<Notify>,
@@ -88,25 +88,28 @@ impl ASGIHTTPProtocol {
     fn send_body<'p>(
         &self,
         py: Python<'p>,
-        tx: &mpsc::UnboundedSender<body::Bytes>,
+        tx: mpsc::Sender<body::Bytes>,
         body: Box<[u8]>,
         close: bool,
     ) -> PyResult<Bound<'p, PyAny>> {
-        match tx.send(body.into()) {
-            Ok(()) => {
-                if close {
-                    self.flow_tx_waiter.notify_one();
+        let flow_tx_waiter = self.flow_tx_waiter.clone();
+        let flow_rx_closed = self.flow_rx_closed.clone();
+        future_into_py_futlike(self.rt.clone(), py, async move {
+            match tx.send(body.into()).await {
+                Ok(()) => {
+                    if close {
+                        flow_tx_waiter.notify_one();
+                    }
+                }
+                Err(err) => {
+                    if !flow_rx_closed.load(atomic::Ordering::Acquire) {
+                        log::info!("ASGI transport error: {err:?}");
+                    }
+                    flow_tx_waiter.notify_one();
                 }
             }
-            Err(err) => {
-                if !self.flow_rx_closed.load(atomic::Ordering::Acquire) {
-                    log::info!("ASGI transport error: {err:?}");
-                }
-                self.flow_tx_waiter.notify_one();
-            }
-        }
-
-        empty_future_into_py(py)
+            FutureResultToPy::None
+        })
     }
 
     pub fn tx(&self) -> Option<oneshot::Sender<HTTPResponse>> {
@@ -202,14 +205,9 @@ impl ASGIHTTPProtocol {
 
                 self.response_chunked.store(true, atomic::Ordering::Relaxed);
                 let (status, headers) = intent;
-                let (body_tx, body_rx) = mpsc::unbounded_channel::<body::Bytes>();
-                let body_stream = http_body_util::StreamBody::new(
-                    tokio_stream::wrappers::UnboundedReceiverStream::new(body_rx)
-                        .map(body::Frame::data)
-                        .map(Result::Ok),
-                );
-                *self.body_tx.lock().unwrap() = Some(body_tx.clone());
-                self.send_response(status, headers, BodyExt::boxed(body_stream));
+                let (body_tx, txbody) = body_stream_channel();
+                *self.body_tx.lock().unwrap() = Some(body_tx);
+                self.send_response(status, headers, txbody);
                 empty_future_into_py(py)
             }
             Ok(ASGIMessageType::HTTPResponseBody((body, more))) => {
@@ -235,25 +233,20 @@ impl ASGIHTTPProtocol {
                     (true, true, false) => match self.response_intent.lock().unwrap().take() {
                         Some((status, headers)) => {
                             self.response_chunked.store(true, atomic::Ordering::Relaxed);
-                            let (body_tx, body_rx) = mpsc::unbounded_channel::<body::Bytes>();
-                            let body_stream = http_body_util::StreamBody::new(
-                                tokio_stream::wrappers::UnboundedReceiverStream::new(body_rx)
-                                    .map(body::Frame::data)
-                                    .map(Result::Ok),
-                            );
+                            let (body_tx, txbody) = body_stream_channel();
                             *self.body_tx.lock().unwrap() = Some(body_tx.clone());
-                            self.send_response(status, headers, BodyExt::boxed(body_stream));
-                            self.send_body(py, &body_tx, body, false)
+                            self.send_response(status, headers, txbody);
+                            self.send_body(py, body_tx, body, false)
                         }
                         _ => error_flow!("Response already finished"),
                     },
                     (true, true, true) => match &*self.body_tx.lock().unwrap() {
-                        Some(tx) => self.send_body(py, tx, body, false),
+                        Some(tx) => self.send_body(py, tx.clone(), body, false),
                         _ => error_flow!("Transport not initialized or closed"),
                     },
                     (true, false, true) => match self.body_tx.lock().unwrap().take() {
                         Some(tx) => match body.is_empty() {
-                            false => self.send_body(py, &tx, body, true),
+                            false => self.send_body(py, tx, body, true),
                             true => {
                                 self.flow_tx_waiter.notify_one();
                                 empty_future_into_py(py)

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,15 +1,28 @@
+use futures::StreamExt;
 use http_body_util::BodyExt;
 use hyper::{
     Response,
-    body::Bytes,
+    body::{Bytes, Frame},
     header::{HeaderValue, SERVER as HK_SERVER},
 };
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
 
 pub(crate) type HTTPRequest = hyper::Request<hyper::body::Incoming>;
 pub(crate) type HTTPResponseBody = http_body_util::combinators::BoxBody<Bytes, anyhow::Error>;
 pub(crate) type HTTPResponse = hyper::Response<HTTPResponseBody>;
 
 pub(crate) const HV_SERVER: HeaderValue = HeaderValue::from_static("granian");
+
+// NOTE: bounded so a slow client applies backpressure to the producer instead of an unbounded
+//       buffer growing without limit; capacity chosen empirically, see the fix this introduced.
+const STREAM_CHANNEL_CAPACITY: usize = 32;
+
+pub(crate) fn body_stream_channel() -> (mpsc::Sender<Bytes>, HTTPResponseBody) {
+    let (tx, rx) = mpsc::channel::<Bytes>(STREAM_CHANNEL_CAPACITY);
+    let body = http_body_util::StreamBody::new(ReceiverStream::new(rx).map(Frame::data).map(Result::Ok));
+    (tx, BodyExt::boxed(body))
+}
 
 #[derive(Clone)]
 pub(crate) enum HTTPProto {

--- a/src/rsgi/io.rs
+++ b/src/rsgi/io.rs
@@ -15,7 +15,8 @@ use super::{
 };
 use crate::{
     conversion::FutureResultToPy,
-    runtime::{RuntimeRef, empty_future_into_py, err_future_into_py, future_into_py_futlike},
+    http::body_stream_channel,
+    runtime::{RuntimeRef, empty_future_into_py, future_into_py_futlike},
     ws::{HyperWebsocket, UpgradeData, WSRxStream, WSTxStream},
 };
 
@@ -23,12 +24,23 @@ pub(crate) type WebsocketDetachedTransport = (i32, bool, Option<WSTxStream>);
 
 #[pyclass(frozen, module = "granian._granian")]
 pub(crate) struct RSGIHTTPStreamTransport {
-    tx: mpsc::UnboundedSender<body::Bytes>,
+    rt: RuntimeRef,
+    tx: mpsc::Sender<body::Bytes>,
 }
 
 impl RSGIHTTPStreamTransport {
-    pub fn new(transport: mpsc::UnboundedSender<body::Bytes>) -> Self {
-        Self { tx: transport }
+    pub fn new(rt: RuntimeRef, transport: mpsc::Sender<body::Bytes>) -> Self {
+        Self { rt, tx: transport }
+    }
+
+    fn send_frame<'p>(&self, py: Python<'p>, frame: body::Bytes) -> PyResult<Bound<'p, PyAny>> {
+        let tx = self.tx.clone();
+        future_into_py_futlike(self.rt.clone(), py, async move {
+            match tx.send(frame).await {
+                Ok(()) => FutureResultToPy::None,
+                _ => FutureResultToPy::Err(error_stream!()),
+            }
+        })
     }
 }
 
@@ -38,17 +50,11 @@ impl RSGIHTTPStreamTransport {
 impl RSGIHTTPStreamTransport {
     fn send_bytes<'p>(&self, py: Python<'p>, data: Cow<[u8]>) -> PyResult<Bound<'p, PyAny>> {
         let bdata = body::Bytes::from(std::convert::Into::<Box<[u8]>>::into(data));
-        match self.tx.send(bdata) {
-            Ok(()) => empty_future_into_py(py),
-            _ => err_future_into_py(py, error_stream!()),
-        }
+        self.send_frame(py, bdata)
     }
 
     fn send_str<'p>(&self, py: Python<'p>, data: String) -> PyResult<Bound<'p, PyAny>> {
-        match self.tx.send(body::Bytes::from(data)) {
-            Ok(()) => empty_future_into_py(py),
-            _ => err_future_into_py(py, error_stream!()),
-        }
+        self.send_frame(py, body::Bytes::from(data))
     }
 }
 
@@ -203,18 +209,9 @@ impl RSGIHTTPProtocol {
         headers: Vec<(PyBackedStr, PyBackedStr)>,
     ) -> PyResult<Bound<'p, RSGIHTTPStreamTransport>> {
         if let Some(tx) = self.tx.lock().unwrap().take() {
-            let (body_tx, body_rx) = mpsc::unbounded_channel::<body::Bytes>();
-            let body_stream = http_body_util::StreamBody::new(
-                tokio_stream::wrappers::UnboundedReceiverStream::new(body_rx)
-                    .map(body::Frame::data)
-                    .map(Result::Ok),
-            );
-            _ = tx.send(PyResponse::Body(PyResponseBody::new(
-                status,
-                headers,
-                BodyExt::boxed(body_stream),
-            )));
-            let trx = Py::new(py, RSGIHTTPStreamTransport::new(body_tx))?;
+            let (body_tx, txbody) = body_stream_channel();
+            _ = tx.send(PyResponse::Body(PyResponseBody::new(status, headers, txbody)));
+            let trx = Py::new(py, RSGIHTTPStreamTransport::new(self.rt.clone(), body_tx))?;
             return Ok(trx.into_bound(py));
         }
         error_proto!()

--- a/src/wsgi/io.rs
+++ b/src/wsgi/io.rs
@@ -1,11 +1,14 @@
-use futures::StreamExt;
 use http_body_util::BodyExt;
 use hyper::{body, header::HeaderMap};
 use pyo3::{prelude::*, pybacked::PyBackedStr};
 use std::{borrow::Cow, sync::Mutex};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::oneshot;
 
-use crate::{conversion::headers_from_py, http::HTTPResponseBody, utils::log_application_callable_exception};
+use crate::{
+    conversion::headers_from_py,
+    http::{HTTPResponseBody, body_stream_channel},
+    utils::log_application_callable_exception,
+};
 
 // NOTE: for unknown reasons, under some circumstances (`threading` module usage in app?)
 //       this gets shared across threads. So it can't be `unsendable` (yet?).
@@ -40,14 +43,7 @@ impl WSGIProtocol {
 
     fn response_iter(&self, py: Python, status: u16, headers: Vec<(PyBackedStr, PyBackedStr)>, body: Bound<PyAny>) {
         if let Some(tx) = self.tx.lock().map_or(None, |mut v| v.take()) {
-            let (body_tx, body_rx) = mpsc::unbounded_channel::<body::Bytes>();
-
-            let body_stream = http_body_util::StreamBody::new(
-                tokio_stream::wrappers::UnboundedReceiverStream::new(body_rx)
-                    .map(body::Frame::data)
-                    .map(Result::Ok),
-            );
-            let txbody = BodyExt::boxed(body_stream);
+            let (body_tx, txbody) = body_stream_channel();
             let _ = tx.send((status, headers_from_py(headers), txbody));
 
             let mut closed = false;
@@ -72,7 +68,7 @@ impl WSGIProtocol {
                         closed = true;
                         None
                     }
-                } && body_tx.send(frame).is_ok()
+                } && py.detach(|| body_tx.blocking_send(frame)).is_ok()
                 {
                     continue;
                 }


### PR DESCRIPTION
## Summary

Fixes #885.

Streamed response bodies (WSGI iterables, ASGI `http.response.body` streaming, RSGI `response_stream`) are handed to the hyper transport over an `mpsc` channel. It was unbounded, and the producer side did a fire-and-forget send, so a producer that outpaces the client (e.g. reading a file from page cache at GB/s while a client drains the socket at MB/s) buffered the entire gap in memory.

- `src/wsgi/io.rs`: `response_iter` already runs on a dedicated blocking OS thread (`spawn_blocking`), so it now does a real `blocking_send` with the GIL released (`py.detach`) instead of a non-blocking `send`.
- `src/asgi/io.rs` / `src/rsgi/io.rs`: the send methods are already `await`ed from Python (ASGI `send()`, RSGI `send_bytes`/`send_str`), but the Rust side resolved the returned future immediately without ever honoring channel capacity. They now genuinely `await` the bounded send, so an already-`await`ed call finally does what it always looked like it did.
- All three now share a bounded channel (32 slots) built by a new `crate::http::body_stream_channel()` helper, replacing four near-identical unbounded-channel-construction blocks that were duplicated across the three protocol modules.

## Test plan

- `cargo fmt --all -- --check`, `cargo clippy --tests` with the project's `lint-rust` flags: clean.
- Full `pytest` suite: 176 passed, 0 failed, 4 skipped (unchanged from master).
- Manual repro: served an 800MB file over WSGI to a client throttled to 20MB/s via `curl --limit-rate`, sampling worker RSS:
  - Before this change: **~866MB** peak RSS (essentially the whole file buffered).
  - After this change: **~118MB** peak RSS.