### PR TITLE
Backport unified `WorkerSignal` class, refactor worker main loop

### DIFF
--- a/granian/_granian.pyi
+++ b/granian/_granian.pyi
@@ -1,5 +1,4 @@
 import sys
-import threading
 from typing import Any
 
 from ._types import WebsocketMessage
@@ -50,12 +49,7 @@ class WSGIScope:
 class WorkerSignal:
     def __init__(self) -> None: ...
     def set(self) -> None: ...
-
-class WorkerSignalSync:
-    qs: threading.Event
-
-    def __init__(self) -> None: ...
-    def set(self) -> None: ...
+    def add_cb(self, cb: Any) -> None: ...
 
 class ASGIWorker:
     def __new__(

--- a/granian/_signals.py
+++ b/granian/_signals.py
@@ -1,8 +1,7 @@
 import signal
 import sys
-import threading
 
-from ._granian import WorkerSignal, WorkerSignalSync
+from ._granian import WorkerSignal
 
 
 def _get_signals():
@@ -38,7 +37,7 @@ def set_loop_signals(loop):
 
 
 def set_sync_signals():
-    signal_event = WorkerSignalSync(threading.Event())
+    signal_event = WorkerSignal()
 
     def signal_handler(signum, frame):
         signal_event.set()

--- a/granian/server/embed.py
+++ b/granian/server/embed.py
@@ -221,6 +221,15 @@ class Server(AbstractServer[AsyncWorker]):
         scope_opts: dict[str, Any],
     ):
         wcallback = _future_watcher_wrapper(_asgi_call_wrap(callback, scope_opts, {}, log_access_fmt))
+        fut = loop.create_future()
+
+        def shutdown_glue():
+            def _inner():
+                fut.set_result(None)
+
+            loop.call_soon_threadsafe(_inner)
+
+        shutdown_event.add_cb(shutdown_glue)
 
         worker = ASGIWorker(
             worker_id,
@@ -241,7 +250,8 @@ class Server(AbstractServer[AsyncWorker]):
         )
         serve = worker.serve_async_uds if (sock[0] or sock[1]).is_uds() else worker.serve_async
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
-        await serve(scheduler, loop, shutdown_event)
+        serve(scheduler, loop, shutdown_event)
+        await fut
 
     @staticmethod
     @AsyncWorker.wrap_target
@@ -276,6 +286,16 @@ class Server(AbstractServer[AsyncWorker]):
             logger.error('ASGI lifespan startup failed', exc_info=lifespan_handler.exc)
             raise FatalError('ASGI lifespan startup')
 
+        fut = loop.create_future()
+
+        def shutdown_glue():
+            def _inner():
+                fut.set_result(None)
+
+            loop.call_soon_threadsafe(_inner)
+
+        shutdown_event.add_cb(shutdown_glue)
+
         worker = ASGIWorker(
             worker_id,
             sock,
@@ -295,7 +315,8 @@ class Server(AbstractServer[AsyncWorker]):
         )
         serve = worker.serve_async_uds if (sock[0] or sock[1]).is_uds() else worker.serve_async
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
-        await serve(scheduler, loop, shutdown_event)
+        serve(scheduler, loop, shutdown_event)
+        await fut
         await lifespan_handler.shutdown()
 
     @staticmethod
@@ -323,6 +344,16 @@ class Server(AbstractServer[AsyncWorker]):
     ):
         callback, callback_init, callback_del = _rsgi_cbs_from_target(callback)
         wcallback = _future_watcher_wrapper(_rsgi_call_wrap(callback, log_access_fmt))
+        fut = loop.create_future()
+
+        def shutdown_glue():
+            def _inner():
+                fut.set_result(None)
+
+            loop.call_soon_threadsafe(_inner)
+
+        shutdown_event.add_cb(shutdown_glue)
+
         callback_init(loop)
 
         worker = RSGIWorker(
@@ -344,7 +375,8 @@ class Server(AbstractServer[AsyncWorker]):
         )
         serve = worker.serve_async_uds if (sock[0] or sock[1]).is_uds() else worker.serve_async
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
-        await serve(scheduler, loop, shutdown_event)
+        serve(scheduler, loop, shutdown_event)
+        await fut
         callback_del(loop)
 
     async def _respawn_workers(self, workers, spawn_target, target_loader, delay: float = 0):

--- a/granian/server/mp.py
+++ b/granian/server/mp.py
@@ -1,7 +1,9 @@
+import asyncio
 import multiprocessing
 import os
 import socket
 import sys
+import threading
 from collections.abc import Callable
 from functools import wraps
 from typing import Any
@@ -139,6 +141,18 @@ class MPServer(AbstractServer[WorkerProcess]):
 
         wcallback = _future_watcher_wrapper(_asgi_call_wrap(callback, scope_opts, {}, log_access_fmt))
         shutdown_event = set_loop_signals(loop)
+        evp = asyncio.Event()
+
+        async def _main():
+            await evp.wait()
+
+        def shutdown_glue():
+            def _inner():
+                evp.set()
+
+            loop.call_soon_threadsafe(_inner)
+
+        shutdown_event.add_cb(shutdown_glue)
 
         worker = ASGIWorker(
             worker_id,
@@ -160,6 +174,7 @@ class MPServer(AbstractServer[WorkerProcess]):
         serve = getattr(worker, WORKERS_METHODS[runtime_mode][(sock[0] or sock[1]).is_uds()])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
         serve(scheduler, loop, shutdown_event)
+        loop.run_until_complete(_main())
 
     @staticmethod
     @WorkerProcess.wrap_target
@@ -193,6 +208,18 @@ class MPServer(AbstractServer[WorkerProcess]):
             _asgi_call_wrap(callback, scope_opts, lifespan_handler.state, log_access_fmt)
         )
         shutdown_event = set_loop_signals(loop)
+        evp = asyncio.Event()
+
+        async def _main():
+            await evp.wait()
+
+        def shutdown_glue():
+            def _inner():
+                evp.set()
+
+            loop.call_soon_threadsafe(_inner)
+
+        shutdown_event.add_cb(shutdown_glue)
 
         loop.run_until_complete(lifespan_handler.startup())
         if lifespan_handler.interrupt:
@@ -219,6 +246,7 @@ class MPServer(AbstractServer[WorkerProcess]):
         serve = getattr(worker, WORKERS_METHODS[runtime_mode][(sock[0] or sock[1]).is_uds()])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
         serve(scheduler, loop, shutdown_event)
+        loop.run_until_complete(_main())
         loop.run_until_complete(lifespan_handler.shutdown())
 
     @staticmethod
@@ -251,6 +279,19 @@ class MPServer(AbstractServer[WorkerProcess]):
         callback, callback_init, callback_del = _rsgi_cbs_from_target(callback)
         wcallback = _future_watcher_wrapper(_rsgi_call_wrap(callback, log_access_fmt))
         shutdown_event = set_loop_signals(loop)
+        evp = asyncio.Event()
+
+        async def _main():
+            await evp.wait()
+
+        def shutdown_glue():
+            def _inner():
+                evp.set()
+
+            loop.call_soon_threadsafe(_inner)
+
+        shutdown_event.add_cb(shutdown_glue)
+
         callback_init(loop)
 
         worker = RSGIWorker(
@@ -273,6 +314,7 @@ class MPServer(AbstractServer[WorkerProcess]):
         serve = getattr(worker, WORKERS_METHODS[runtime_mode][(sock[0] or sock[1]).is_uds()])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
         serve(scheduler, loop, shutdown_event)
+        loop.run_until_complete(_main())
         callback_del(loop)
 
     @staticmethod
@@ -304,6 +346,15 @@ class MPServer(AbstractServer[WorkerProcess]):
 
         wcallback = _wsgi_call_wrap(callback, scope_opts, log_access_fmt)
         shutdown_event = set_sync_signals()
+        evp = threading.Event()
+
+        def _main():
+            evp.wait()
+
+        def shutdown_glue():
+            evp.set()
+
+        shutdown_event.add_cb(shutdown_glue)
 
         worker = WSGIWorker(
             worker_id,
@@ -324,6 +375,7 @@ class MPServer(AbstractServer[WorkerProcess]):
         serve = getattr(worker, WORKERS_METHODS[runtime_mode][(sock[0] or sock[1]).is_uds()])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
         serve(scheduler, loop, shutdown_event)
+        _main()
 
     def _init_shared_socket(self):
         super()._init_shared_socket()

--- a/granian/server/mt.py
+++ b/granian/server/mt.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 import threading
 from collections.abc import Callable
@@ -5,7 +6,7 @@ from functools import wraps
 from typing import Any
 
 from .._futures import _future_watcher_wrapper, _new_cbscheduler
-from .._granian import ASGIWorker, RSGIWorker, WorkerSignal, WorkerSignalSync, WSGIWorker
+from .._granian import ASGIWorker, RSGIWorker, WorkerSignal, WSGIWorker
 from .._loops import loops
 from .._types import SSLCtx
 from ..asgi import LifespanProtocol, _callback_wrapper as _asgi_call_wrap
@@ -19,7 +20,6 @@ from .common import (
     HTTP1Settings,
     HTTP2Settings,
     HTTPModes,
-    Interfaces,
     RuntimeModes,
     TaskImpl,
     logger,
@@ -95,6 +95,18 @@ class MTServer(AbstractServer[WorkerThread]):
         metrics: Any,
     ):
         wcallback = _future_watcher_wrapper(_asgi_call_wrap(callback, scope_opts, {}, log_access_fmt))
+        evp = asyncio.Event()
+
+        async def _main():
+            await evp.wait()
+
+        def shutdown_glue():
+            def _inner():
+                evp.set()
+
+            loop.call_soon_threadsafe(_inner)
+
+        shutdown_event.add_cb(shutdown_glue)
 
         worker = ASGIWorker(
             worker_id,
@@ -116,6 +128,7 @@ class MTServer(AbstractServer[WorkerThread]):
         serve = getattr(worker, WORKERS_METHODS[runtime_mode][(sock[0] or sock[1]).is_uds()])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
         serve(scheduler, loop, shutdown_event)
+        loop.run_until_complete(_main())
 
     @staticmethod
     @WorkerThread.wrap_target
@@ -146,6 +159,18 @@ class MTServer(AbstractServer[WorkerThread]):
         wcallback = _future_watcher_wrapper(
             _asgi_call_wrap(callback, scope_opts, lifespan_handler.state, log_access_fmt)
         )
+        evp = asyncio.Event()
+
+        async def _main():
+            await evp.wait()
+
+        def shutdown_glue():
+            def _inner():
+                evp.set()
+
+            loop.call_soon_threadsafe(_inner)
+
+        shutdown_event.add_cb(shutdown_glue)
 
         loop.run_until_complete(lifespan_handler.startup())
         if lifespan_handler.interrupt:
@@ -172,6 +197,7 @@ class MTServer(AbstractServer[WorkerThread]):
         serve = getattr(worker, WORKERS_METHODS[runtime_mode][(sock[0] or sock[1]).is_uds()])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
         serve(scheduler, loop, shutdown_event)
+        loop.run_until_complete(_main())
         loop.run_until_complete(lifespan_handler.shutdown())
 
     @staticmethod
@@ -201,6 +227,19 @@ class MTServer(AbstractServer[WorkerThread]):
     ):
         callback, callback_init, callback_del = _rsgi_cbs_from_target(callback)
         wcallback = _future_watcher_wrapper(_rsgi_call_wrap(callback, log_access_fmt))
+        evp = asyncio.Event()
+
+        async def _main():
+            await evp.wait()
+
+        def shutdown_glue():
+            def _inner():
+                evp.set()
+
+            loop.call_soon_threadsafe(_inner)
+
+        shutdown_event.add_cb(shutdown_glue)
+
         callback_init(loop)
 
         worker = RSGIWorker(
@@ -223,6 +262,7 @@ class MTServer(AbstractServer[WorkerThread]):
         serve = getattr(worker, WORKERS_METHODS[runtime_mode][(sock[0] or sock[1]).is_uds()])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
         serve(scheduler, loop, shutdown_event)
+        loop.run_until_complete(_main())
         callback_del(loop)
 
     @staticmethod
@@ -251,6 +291,15 @@ class MTServer(AbstractServer[WorkerThread]):
         metrics: Any,
     ):
         wcallback = _wsgi_call_wrap(callback, scope_opts, log_access_fmt)
+        evp = threading.Event()
+
+        def _main():
+            evp.wait()
+
+        def shutdown_glue():
+            evp.set()
+
+        shutdown_event.add_cb(shutdown_glue)
 
         worker = WSGIWorker(
             worker_id,
@@ -271,9 +320,10 @@ class MTServer(AbstractServer[WorkerThread]):
         serve = getattr(worker, WORKERS_METHODS[runtime_mode][(sock[0] or sock[1]).is_uds()])
         scheduler = _new_cbscheduler(loop, wcallback, impl_asyncio=task_impl == TaskImpl.asyncio)
         serve(scheduler, loop, shutdown_event)
+        _main()
 
     def _spawn_worker(self, idx, target, callback_loader) -> WorkerThread:
-        sig = WorkerSignalSync(threading.Event()) if self.interface == Interfaces.WSGI else WorkerSignal()
+        sig = WorkerSignal()
 
         return WorkerThread(
             parent=self,

--- a/src/asgi/serve.rs
+++ b/src/asgi/serve.rs
@@ -116,13 +116,19 @@ impl ASGIWorker {
         );
     }
 
-    fn serve_str(&self, callback: Py<CallbackScheduler>, event_loop: &Bound<PyAny>, signal: Py<WorkerSignal>) {
+    fn serve_str(
+        &self,
+        py: Python,
+        callback: Py<CallbackScheduler>,
+        event_loop: &Bound<PyAny>,
+        signal: Py<WorkerSignal>,
+    ) {
         gen_serve_match!(
             crate::serve::serve_st,
             WorkerAcceptorTcpPlain,
             WorkerAcceptorTcpTls,
             self,
-            (),
+            py,
             callback,
             event_loop,
             signal,
@@ -131,24 +137,25 @@ impl ASGIWorker {
         );
     }
 
-    fn serve_async<'p>(
+    fn serve_async(
         &self,
+        py: Python,
         callback: Py<CallbackScheduler>,
-        event_loop: &Bound<'p, PyAny>,
+        event_loop: &Bound<PyAny>,
         signal: Py<WorkerSignal>,
-    ) -> Bound<'p, PyAny> {
+    ) {
         gen_serve_match!(
             crate::serve::serve_fut,
             WorkerAcceptorTcpPlain,
             WorkerAcceptorTcpTls,
             self,
-            (),
+            py,
             callback,
             event_loop,
             signal,
             handle,
             handle_ws
-        )
+        );
     }
 
     #[cfg(unix)]
@@ -174,13 +181,19 @@ impl ASGIWorker {
     }
 
     #[cfg(unix)]
-    fn serve_str_uds(&self, callback: Py<CallbackScheduler>, event_loop: &Bound<PyAny>, signal: Py<WorkerSignal>) {
+    fn serve_str_uds(
+        &self,
+        py: Python,
+        callback: Py<CallbackScheduler>,
+        event_loop: &Bound<PyAny>,
+        signal: Py<WorkerSignal>,
+    ) {
         gen_serve_match!(
             crate::serve::serve_st_uds,
             WorkerAcceptorUdsPlain,
             WorkerAcceptorUdsTls,
             self,
-            (),
+            py,
             callback,
             event_loop,
             signal,
@@ -190,23 +203,24 @@ impl ASGIWorker {
     }
 
     #[cfg(unix)]
-    fn serve_async_uds<'p>(
+    fn serve_async_uds(
         &self,
+        py: Python,
         callback: Py<CallbackScheduler>,
-        event_loop: &Bound<'p, PyAny>,
+        event_loop: &Bound<PyAny>,
         signal: Py<WorkerSignal>,
-    ) -> Bound<'p, PyAny> {
+    ) {
         gen_serve_match!(
             crate::serve::serve_fut_uds,
             WorkerAcceptorUdsPlain,
             WorkerAcceptorUdsTls,
             self,
-            (),
+            py,
             callback,
             event_loop,
             signal,
             handle,
             handle_ws
-        )
+        );
     }
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -81,7 +81,7 @@ impl IPCReceiverHandle {
 
             let idx = handle.get().id;
             let mut pyrx = {
-                let guard = sig.get().rx.lock().unwrap();
+                let guard = sig.get().arx.lock().unwrap();
                 guard.clone().unwrap()
             };
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -201,7 +201,7 @@ impl MetricsExporter {
     }
 
     fn run(pyself: Py<Self>, py: Python, sock: Py<crate::net::SocketHolder>, sig: Py<crate::workers::WorkerSignal>) {
-        let sig = sig.get().rx.lock().unwrap().take().unwrap();
+        let sig = sig.get().arx.lock().unwrap().take().unwrap();
         let pynone = py.None().into_any().into();
         let exp = pyself.clone_ref(py);
 

--- a/src/rsgi/serve.rs
+++ b/src/rsgi/serve.rs
@@ -116,13 +116,19 @@ impl RSGIWorker {
         );
     }
 
-    fn serve_str(&self, callback: Py<CallbackScheduler>, event_loop: &Bound<PyAny>, signal: Py<WorkerSignal>) {
+    fn serve_str(
+        &self,
+        py: Python,
+        callback: Py<CallbackScheduler>,
+        event_loop: &Bound<PyAny>,
+        signal: Py<WorkerSignal>,
+    ) {
         gen_serve_match!(
             crate::serve::serve_st,
             WorkerAcceptorTcpPlain,
             WorkerAcceptorTcpTls,
             self,
-            (),
+            py,
             callback,
             event_loop,
             signal,
@@ -131,24 +137,25 @@ impl RSGIWorker {
         );
     }
 
-    fn serve_async<'p>(
+    fn serve_async(
         &self,
+        py: Python,
         callback: Py<CallbackScheduler>,
-        event_loop: &Bound<'p, PyAny>,
+        event_loop: &Bound<PyAny>,
         signal: Py<WorkerSignal>,
-    ) -> Bound<'p, PyAny> {
+    ) {
         gen_serve_match!(
             crate::serve::serve_fut,
             WorkerAcceptorTcpPlain,
             WorkerAcceptorTcpTls,
             self,
-            (),
+            py,
             callback,
             event_loop,
             signal,
             handle,
             handle_ws
-        )
+        );
     }
 
     #[cfg(unix)]
@@ -174,13 +181,19 @@ impl RSGIWorker {
     }
 
     #[cfg(unix)]
-    fn serve_str_uds(&self, callback: Py<CallbackScheduler>, event_loop: &Bound<PyAny>, signal: Py<WorkerSignal>) {
+    fn serve_str_uds(
+        &self,
+        py: Python,
+        callback: Py<CallbackScheduler>,
+        event_loop: &Bound<PyAny>,
+        signal: Py<WorkerSignal>,
+    ) {
         gen_serve_match!(
             crate::serve::serve_st_uds,
             WorkerAcceptorUdsPlain,
             WorkerAcceptorUdsTls,
             self,
-            (),
+            py,
             callback,
             event_loop,
             signal,
@@ -190,23 +203,24 @@ impl RSGIWorker {
     }
 
     #[cfg(unix)]
-    fn serve_async_uds<'p>(
+    fn serve_async_uds(
         &self,
+        py: Python,
         callback: Py<CallbackScheduler>,
-        event_loop: &Bound<'p, PyAny>,
+        event_loop: &Bound<PyAny>,
         signal: Py<WorkerSignal>,
-    ) -> Bound<'p, PyAny> {
+    ) {
         gen_serve_match!(
             crate::serve::serve_fut_uds,
             WorkerAcceptorUdsPlain,
             WorkerAcceptorUdsTls,
             self,
-            (),
+            py,
             callback,
             event_loop,
             signal,
             handle,
             handle_ws
-        )
+        );
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,8 +1,5 @@
 use pyo3::{IntoPyObjectExt, prelude::*};
-use std::{
-    future::Future,
-    sync::{Arc, Mutex},
-};
+use std::{future::Future, sync::Arc};
 use tokio::{
     runtime::Builder as RuntimeBuilder,
     task::{JoinHandle, LocalSet},
@@ -330,40 +327,6 @@ where
     });
 
     Ok(py_fut.into_bound(py))
-}
-
-#[allow(unused_must_use)]
-pub(crate) fn run_until_complete<F>(rt: &RuntimeWrapper, event_loop: Bound<PyAny>, fut: F) -> PyResult<()>
-where
-    F: Future<Output = PyResult<()>> + Send + 'static,
-{
-    let result_tx = Arc::new(Mutex::new(None));
-    let result_rx = Arc::clone(&result_tx);
-
-    let py_fut = event_loop.call_method0("create_future")?;
-    let loop_tx = event_loop.clone().unbind();
-    let future_tx = py_fut.clone().unbind();
-
-    rt.inner.spawn(async move {
-        let _ = fut.await;
-        if let Ok(mut result) = result_tx.lock() {
-            *result = Some(());
-        }
-
-        // NOTE: we don't care if we block the runtime.
-        //       `run_until_complete` is used only for the workers main loop.
-        Python::attach(move |py| {
-            let res_method = future_tx.getattr(py, "set_result").unwrap();
-            let _ = loop_tx.call_method(py, "call_soon_threadsafe", (res_method, py.None()), None);
-            future_tx.drop_ref(py);
-            loop_tx.drop_ref(py);
-        });
-    });
-
-    event_loop.call_method1("run_until_complete", (py_fut,))?;
-
-    result_rx.lock().unwrap().take().unwrap();
-    Ok(())
 }
 
 pub(crate) fn block_on_local<F>(rt: &RuntimeWrapper, local: LocalSet, fut: F)

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1,5 +1,5 @@
 use pyo3::prelude::*;
-use std::sync::Arc;
+use std::sync::{Arc, Condvar, Mutex};
 
 use super::workers::{Worker, WorkerAcceptor, WorkerConfig, WorkerSignal};
 
@@ -50,7 +50,8 @@ macro_rules! serve_fn {
                 )
             });
             let rth = rt.handler();
-            let srx = signal.get().rx.lock().unwrap().take().unwrap();
+            let (stx, srx) = tokio::sync::watch::channel(false);
+            let cvar = Arc::new((Mutex::new(false), Condvar::new()));
             let mc_notify = Arc::new(tokio::sync::Notify::new());
 
             if let Some(metrics_interval) = cfg.metrics.0 {
@@ -80,7 +81,8 @@ macro_rules! serve_fn {
             let wrk = crate::workers::Worker::new(ctx, acceptor, handler, rth, target, metrics.0);
             let tasks = wrk.tasks.clone();
 
-            let main_loop = crate::runtime::run_until_complete(&rt, event_loop.clone(), async move {
+            let ml_cvar = cvar.clone();
+            rt.inner.spawn(async move {
                 wrk.listen(srx, listener, backpressure).await;
 
                 log::info!("Stopping worker-{worker_id}");
@@ -91,22 +93,36 @@ macro_rules! serve_fn {
                 mc_notify.notified().await;
 
                 Python::attach(|_| drop(wrk));
-                Ok(())
+
+                let (lock, cvar) = &*ml_cvar;
+                let mut done = lock.lock().unwrap();
+                *done = true;
+                cvar.notify_one();
             });
 
-            drop(rt);
+            let pysig = signal.clone_ref(py);
+            std::thread::spawn(move || {
+                let pyrx = pysig.get().rx.lock().unwrap().take().unwrap();
+                _ = pyrx.recv();
+                _ = stx.send(true);
 
-            if let Err(err) = main_loop {
-                log::error!("{err}");
-                std::process::exit(1);
-            }
+                let (lock, cvar) = &*cvar;
+                let done = lock.lock().unwrap();
+                let _done = cvar.wait(done);
+
+                Python::attach(|py| {
+                    _ = pysig.get().release(py);
+                    drop(pysig);
+                    drop(rt);
+                });
+            });
         }
     };
 
     (st $name:ident, $listener:ty, $listener_gen:ident) => {
         pub(crate) fn $name<C, A, H, F, M, Ret>(
             cfg: &WorkerConfig,
-            _py: (),
+            py: Python,
             event_loop: &Bound<PyAny>,
             signal: Py<WorkerSignal>,
             metrics: (M, Option<crate::metrics::ArcWorkerMetrics>),
@@ -142,6 +158,52 @@ macro_rules! serve_fn {
             let mut workers = vec![];
 
             let py_loop = Arc::new(event_loop.clone().unbind());
+            let mc_notify = Arc::new(tokio::sync::Notify::new());
+
+            let metrics_thread = if let Some(metrics_interval) = cfg.metrics.0 {
+                let metrics = metrics.1.clone().unwrap();
+                #[cfg(not(Py_GIL_DISABLED))]
+                let ipc = cfg.ipc.as_ref().map(|v| v.clone_ref(py));
+                #[cfg(Py_GIL_DISABLED)]
+                let aggr = cfg.metrics.1.as_ref().map(|v| v.clone_ref(py));
+                let srx = srx.clone();
+                let py_loop = py_loop.clone();
+
+                let thread = std::thread::spawn(move || {
+                    let rt = crate::runtime::init_runtime_st(1, 0, 0, py_loop, None);
+                    let local = tokio::task::LocalSet::new();
+
+                    #[cfg(not(Py_GIL_DISABLED))]
+                    crate::metrics::spawn_ipc_collector(
+                        rt.handler(),
+                        srx,
+                        mc_notify.clone(),
+                        metrics,
+                        metrics_interval,
+                        ipc.unwrap(),
+                    );
+                    #[cfg(Py_GIL_DISABLED)]
+                    crate::metrics::spawn_local_collector(
+                        rt.handler(),
+                        srx,
+                        mc_notify.clone(),
+                        metrics,
+                        metrics_interval,
+                        (worker_id - 1).try_into().unwrap(),
+                        aggr.unwrap(),
+                    );
+
+                    crate::runtime::block_on_local(&rt, local, async move {
+                        mc_notify.notified().await;
+                    });
+
+                    Python::attach(|_| drop(rt));
+                });
+                Some(thread)
+            } else {
+                mc_notify.notify_one();
+                None
+            };
 
             for thread_id in 0..cfg.threads {
                 log::info!("Started worker-{} runtime-{}", worker_id, thread_id + 1);
@@ -188,67 +250,40 @@ macro_rules! serve_fn {
                 }));
             }
 
-            let rtm = crate::runtime::init_runtime_mt(1, 1, 0, 0, Arc::new(event_loop.clone().unbind()), None);
-            let mut pyrx = signal.get().rx.lock().unwrap().take().unwrap();
-            let mc_notify = Arc::new(tokio::sync::Notify::new());
+            let pysig = signal.clone_ref(py);
+            std::thread::spawn(move || {
+                let pyrx = pysig.get().rx.lock().unwrap().take().unwrap();
+                _ = pyrx.recv();
+                _ = stx.send(true).unwrap();
 
-            if let Some(metrics_interval) = cfg.metrics.0 {
-                #[cfg(not(Py_GIL_DISABLED))]
-                crate::metrics::spawn_ipc_collector(
-                    rtm.handler(),
-                    pyrx.clone(),
-                    mc_notify.clone(),
-                    metrics.1.clone().unwrap(),
-                    metrics_interval,
-                    cfg.ipc.as_ref().unwrap().clone_ref(event_loop.py()),
-                );
-                #[cfg(Py_GIL_DISABLED)]
-                crate::metrics::spawn_local_collector(
-                    rtm.handler(),
-                    pyrx.clone(),
-                    mc_notify.clone(),
-                    metrics.1.clone().unwrap(),
-                    metrics_interval,
-                    (cfg.id - 1).try_into().unwrap(),
-                    cfg.metrics.1.as_ref().unwrap().clone_ref(event_loop.py()),
-                );
-            } else {
-                mc_notify.notify_one();
-            }
-
-            let main_loop = crate::runtime::run_until_complete(&rtm, event_loop.clone(), async move {
-                let _ = pyrx.changed().await;
-                stx.send(true).unwrap();
                 log::info!("Stopping worker-{worker_id}");
                 while let Some(worker) = workers.pop() {
                     worker.join().unwrap();
                 }
-                mc_notify.notified().await;
-                Ok(())
+                if let Some(thread) = metrics_thread {
+                    thread.join().unwrap();
+                }
+
+                Python::attach(|py| {
+                    _ = pysig.get().release(py);
+                    drop(pysig);
+                });
             });
-
-            drop(rtm);
-
-            if let Err(err) = main_loop {
-                log::error!("{err}");
-                std::process::exit(1);
-            }
         }
     };
 
     (fut $name:ident, $listener:ty, $listener_gen:ident) => {
-        pub(crate) fn $name<'p, C, A, H, F, M, Ret>(
+        pub(crate) fn $name<C, A, H, F, M, Ret>(
             cfg: &WorkerConfig,
-            _py: (),
-            event_loop: &Bound<'p, PyAny>,
+            py: Python,
+            event_loop: &Bound<PyAny>,
             signal: Py<WorkerSignal>,
             metrics: (M, Option<crate::metrics::ArcWorkerMetrics>),
             ctx: C,
             acceptor: A,
             handler: H,
             target: F,
-        ) -> Bound<'p, PyAny>
-        where
+        ) where
             F: Fn(
                     crate::runtime::RuntimeRef,
                     Arc<tokio::sync::Notify>,
@@ -279,15 +314,14 @@ macro_rules! serve_fn {
             let backpressure = cfg.backpressure;
 
             let (stx, srx) = tokio::sync::watch::channel(false);
-            let pyloop_r1 = Arc::new(event_loop.clone().unbind());
-            let pyloop_r2 = pyloop_r1.clone();
+            let py_loop = Arc::new(event_loop.clone().unbind());
 
             let worker = std::thread::spawn(move || {
                 let rt = crate::runtime::init_runtime_st(
                     blocking_threads,
                     py_threads,
                     py_threads_idle_timeout,
-                    pyloop_r1,
+                    py_loop,
                     metrics.1.clone(),
                 );
                 let rth = rt.handler();
@@ -309,36 +343,18 @@ macro_rules! serve_fn {
                 Python::attach(|_| drop(rt));
             });
 
-            let ret = event_loop.call_method0("create_future").unwrap();
-            let pyfut = ret.clone().unbind();
-
+            let pysig = signal.clone_ref(py);
             std::thread::spawn(move || {
-                let rt = crate::runtime::init_runtime_st(1, 0, 0, pyloop_r2.clone(), None);
-                let local = tokio::task::LocalSet::new();
-
-                let mut pyrx = signal.get().rx.lock().unwrap().take().unwrap();
-                crate::runtime::block_on_local(&rt, local, async move {
-                    let _ = pyrx.changed().await;
-                    stx.send(true).unwrap();
-                    log::info!("Stopping worker-{worker_id}");
-                    worker.join().unwrap();
-                });
+                let pyrx = pysig.get().rx.lock().unwrap().take().unwrap();
+                _ = pyrx.recv();
+                _ = stx.send(true);
+                worker.join().unwrap();
 
                 Python::attach(|py| {
-                    let cb = pyfut.getattr(py, "set_result").unwrap();
-                    _ = pyloop_r2.call_method1(
-                        py,
-                        "call_soon_threadsafe",
-                        (crate::callbacks::PyFutureResultSetter, cb, py.None()),
-                    );
-                    drop(pyfut);
-                    drop(pyloop_r2);
-                    drop(signal);
-                    drop(rt);
+                    _ = pysig.get().release(py);
+                    drop(pysig);
                 });
             });
-
-            ret
         }
     };
 }

--- a/src/workers.rs
+++ b/src/workers.rs
@@ -16,54 +16,45 @@ use super::wsgi::serve::WSGIWorker;
 
 #[pyclass(frozen, module = "granian._granian")]
 pub(crate) struct WorkerSignal {
-    pub rx: Mutex<Option<tokio::sync::watch::Receiver<bool>>>,
-    tx: tokio::sync::watch::Sender<bool>,
+    pub rx: Mutex<Option<crossbeam_channel::Receiver<bool>>>,
+    tx: crossbeam_channel::Sender<bool>,
+    pub arx: Mutex<Option<tokio::sync::watch::Receiver<bool>>>,
+    atx: tokio::sync::watch::Sender<bool>,
+    cb: Mutex<Option<Py<PyAny>>>,
+}
+
+impl WorkerSignal {
+    pub fn release(&self, py: Python) -> PyResult<Py<PyAny>> {
+        match self.cb.lock().unwrap().take() {
+            Some(cb) => cb.call0(py),
+            None => Ok(py.None()),
+        }
+    }
 }
 
 #[pymethods]
 impl WorkerSignal {
     #[new]
     fn new() -> Self {
-        let (tx, rx) = tokio::sync::watch::channel(false);
-        Self {
-            rx: Mutex::new(Some(rx)),
-            tx,
-        }
-    }
-
-    fn set(&self) {
-        let _ = self.tx.send(true);
-    }
-}
-
-#[pyclass(frozen, module = "granian._granian")]
-pub(crate) struct WorkerSignalSync {
-    pub rx: Mutex<Option<crossbeam_channel::Receiver<bool>>>,
-    tx: crossbeam_channel::Sender<bool>,
-    #[pyo3(get)]
-    pub qs: Py<PyAny>,
-}
-
-impl WorkerSignalSync {
-    pub fn release(&self, py: Python) -> PyResult<Py<PyAny>> {
-        self.qs.call_method0(py, "set")
-    }
-}
-
-#[pymethods]
-impl WorkerSignalSync {
-    #[new]
-    fn new(qs: Py<PyAny>) -> Self {
         let (tx, rx) = crossbeam_channel::bounded(1);
+        let (atx, arx) = tokio::sync::watch::channel(false);
         Self {
             rx: Mutex::new(Some(rx)),
             tx,
-            qs,
+            arx: Mutex::new(Some(arx)),
+            atx,
+            cb: Mutex::new(None),
         }
     }
 
+    fn add_cb(&self, cb: Py<PyAny>) {
+        let mut guard = self.cb.lock().unwrap();
+        *guard = Some(cb);
+    }
+
     fn set(&self) {
-        let _ = self.tx.send(true);
+        _ = self.tx.send(true);
+        _ = self.atx.send(true);
     }
 }
 
@@ -1252,7 +1243,6 @@ acceptor_impl!(
 
 pub(crate) fn init_pymodule(module: &Bound<PyModule>) -> PyResult<()> {
     module.add_class::<WorkerSignal>()?;
-    module.add_class::<WorkerSignalSync>()?;
     module.add_class::<ASGIWorker>()?;
     module.add_class::<RSGIWorker>()?;
     module.add_class::<WSGIWorker>()?;

--- a/src/wsgi/serve.rs
+++ b/src/wsgi/serve.rs
@@ -1,16 +1,13 @@
 use pyo3::prelude::*;
-use std::sync::Arc;
-use tokio::task::JoinHandle;
 
 use super::http::handle;
 
 use crate::{
     callbacks::CallbackScheduler,
     conversion::{worker_http1_config_from_py, worker_http2_config_from_py},
-    http::HTTPProto,
     net::{ListenerSpec, SocketHolder},
     serve::gen_serve_match,
-    workers::{Worker, WorkerAcceptor, WorkerConfig, WorkerSignalSync},
+    workers::{WorkerConfig, WorkerSignal},
 };
 
 #[pyclass(frozen, module = "granian._granian")]
@@ -103,10 +100,10 @@ impl WSGIWorker {
         py: Python,
         callback: Py<CallbackScheduler>,
         event_loop: &Bound<PyAny>,
-        signal: Py<WorkerSignalSync>,
+        signal: Py<WorkerSignal>,
     ) {
         gen_serve_match!(
-            serve_mt,
+            crate::serve::serve_mt,
             WorkerAcceptorTcpPlain,
             WorkerAcceptorTcpTls,
             self,
@@ -124,10 +121,10 @@ impl WSGIWorker {
         py: Python,
         callback: Py<CallbackScheduler>,
         event_loop: &Bound<PyAny>,
-        signal: Py<WorkerSignalSync>,
+        signal: Py<WorkerSignal>,
     ) {
         gen_serve_match!(
-            serve_st,
+            crate::serve::serve_st,
             WorkerAcceptorTcpPlain,
             WorkerAcceptorTcpTls,
             self,
@@ -146,10 +143,10 @@ impl WSGIWorker {
         py: Python,
         callback: Py<CallbackScheduler>,
         event_loop: &Bound<PyAny>,
-        signal: Py<WorkerSignalSync>,
+        signal: Py<WorkerSignal>,
     ) {
         gen_serve_match!(
-            serve_mt_uds,
+            crate::serve::serve_mt_uds,
             WorkerAcceptorUdsPlain,
             WorkerAcceptorUdsTls,
             self,
@@ -168,10 +165,10 @@ impl WSGIWorker {
         py: Python,
         callback: Py<CallbackScheduler>,
         event_loop: &Bound<PyAny>,
-        signal: Py<WorkerSignalSync>,
+        signal: Py<WorkerSignal>,
     ) {
         gen_serve_match!(
-            serve_st_uds,
+            crate::serve::serve_st_uds,
             WorkerAcceptorUdsPlain,
             WorkerAcceptorUdsTls,
             self,
@@ -184,270 +181,3 @@ impl WSGIWorker {
         );
     }
 }
-
-macro_rules! serve_fn {
-    (mt $name:ident, $listener:ty, $listener_gen:ident) => {
-        pub(crate) fn $name<C, A, H, F, M, Ret>(
-            cfg: &WorkerConfig,
-            py: Python,
-            event_loop: &Bound<PyAny>,
-            signal: Py<WorkerSignalSync>,
-            metrics: (M, Option<crate::metrics::ArcWorkerMetrics>),
-            ctx: C,
-            acceptor: A,
-            handler: H,
-            target: F,
-        ) where
-            F: Fn(
-                    crate::runtime::RuntimeRef,
-                    Arc<tokio::sync::Notify>,
-                    crate::callbacks::ArcCBScheduler,
-                    crate::net::SockAddr,
-                    crate::net::SockAddr,
-                    crate::http::HTTPRequest,
-                    HTTPProto,
-                ) -> Ret
-                + Copy,
-            M: Clone + Sync,
-            Ret: Future<Output = crate::http::HTTPResponse>,
-            Worker<C, A, H, F, M>: WorkerAcceptor<$listener> + Clone + Send + 'static,
-        {
-            _ = pyo3_log::try_init();
-
-            let worker_id = cfg.id;
-            log::info!("Started worker-{worker_id}");
-
-            let listener = cfg.$listener_gen();
-            let backpressure = cfg.backpressure;
-
-            let rtpyloop = Arc::new(event_loop.clone().unbind());
-            let rt = py.detach(|| {
-                crate::runtime::init_runtime_mt(
-                    cfg.threads,
-                    cfg.blocking_threads,
-                    cfg.py_threads,
-                    cfg.py_threads_idle_timeout,
-                    rtpyloop,
-                    metrics.1.clone(),
-                )
-            });
-            let rth = rt.handler();
-            let (stx, srx) = tokio::sync::watch::channel(false);
-            let mc_notify = Arc::new(tokio::sync::Notify::new());
-
-            if let Some(metrics_interval) = cfg.metrics.0 {
-                #[cfg(not(Py_GIL_DISABLED))]
-                crate::metrics::spawn_ipc_collector(
-                    rth.clone(),
-                    srx.clone(),
-                    mc_notify.clone(),
-                    metrics.1.clone().unwrap(),
-                    metrics_interval,
-                    cfg.ipc.as_ref().unwrap().clone_ref(py),
-                );
-                #[cfg(Py_GIL_DISABLED)]
-                crate::metrics::spawn_local_collector(
-                    rth.clone(),
-                    srx.clone(),
-                    mc_notify.clone(),
-                    metrics.1.clone().unwrap(),
-                    metrics_interval,
-                    (cfg.id - 1).try_into().unwrap(),
-                    cfg.metrics.1.as_ref().unwrap().clone_ref(py),
-                );
-            } else {
-                mc_notify.notify_one();
-            }
-
-            let wrk = crate::workers::Worker::new(ctx, acceptor, handler, rth, target, metrics.0);
-
-            let main_loop: JoinHandle<anyhow::Result<()>> = rt.inner.spawn(async move {
-                wrk.clone().listen(srx, listener, backpressure).await;
-
-                log::info!("Stopping worker-{worker_id}");
-
-                wrk.tasks.close();
-                wrk.tasks.wait().await;
-                mc_notify.notified().await;
-
-                Python::attach(|_| drop(wrk));
-                Ok(())
-            });
-
-            let pysig = signal.clone_ref(py);
-            std::thread::spawn(move || {
-                let pyrx = pysig.get().rx.lock().unwrap().take().unwrap();
-                _ = pyrx.recv();
-                stx.send(true).unwrap();
-
-                while !main_loop.is_finished() {
-                    std::thread::sleep(std::time::Duration::from_millis(1));
-                }
-
-                Python::attach(|py| {
-                    _ = pysig.get().release(py);
-                    drop(pysig);
-                });
-            });
-
-            _ = signal.get().qs.call_method0(py, pyo3::intern!(py, "wait"));
-        }
-    };
-    (st $name:ident, $listener:ty, $listener_gen:ident) => {
-        pub(crate) fn $name<C, A, H, F, M, Ret>(
-            cfg: &WorkerConfig,
-            py: Python,
-            event_loop: &Bound<PyAny>,
-            signal: Py<WorkerSignalSync>,
-            metrics: (M, Option<crate::metrics::ArcWorkerMetrics>),
-            ctx: C,
-            acceptor: A,
-            handler: H,
-            target: F,
-        ) where
-            F: Fn(
-                    crate::runtime::RuntimeRef,
-                    Arc<tokio::sync::Notify>,
-                    crate::callbacks::ArcCBScheduler,
-                    crate::net::SockAddr,
-                    crate::net::SockAddr,
-                    crate::http::HTTPRequest,
-                    HTTPProto,
-                ) -> Ret
-                + Copy
-                + Send,
-            Ret: Future<Output = crate::http::HTTPResponse>,
-            C: Clone + Send + 'static,
-            A: Clone + Send + 'static,
-            H: Clone + Send + 'static,
-            M: Clone + Send,
-            Worker<C, A, H, F, M>: WorkerAcceptor<$listener> + Clone + Send + 'static,
-        {
-            _ = pyo3_log::try_init();
-
-            let worker_id = cfg.id;
-            log::info!("Started worker-{worker_id}");
-
-            let (stx, srx) = tokio::sync::watch::channel(false);
-            let mut workers = vec![];
-            let py_loop = Arc::new(event_loop.clone().unbind());
-            let mc_notify = Arc::new(tokio::sync::Notify::new());
-
-            let metrics_thread = if let Some(metrics_interval) = cfg.metrics.0 {
-                let metrics = metrics.1.clone().unwrap();
-                #[cfg(not(Py_GIL_DISABLED))]
-                let ipc = cfg.ipc.as_ref().map(|v| v.clone_ref(py));
-                #[cfg(Py_GIL_DISABLED)]
-                let aggr = cfg.metrics.1.as_ref().map(|v| v.clone_ref(py));
-                let srx = srx.clone();
-                let py_loop = py_loop.clone();
-
-                let thread = std::thread::spawn(move || {
-                    let rt = crate::runtime::init_runtime_st(1, 0, 0, py_loop, None);
-                    let local = tokio::task::LocalSet::new();
-
-                    #[cfg(not(Py_GIL_DISABLED))]
-                    crate::metrics::spawn_ipc_collector(
-                        rt.handler(),
-                        srx,
-                        mc_notify.clone(),
-                        metrics,
-                        metrics_interval,
-                        ipc.unwrap(),
-                    );
-                    #[cfg(Py_GIL_DISABLED)]
-                    crate::metrics::spawn_local_collector(
-                        rt.handler(),
-                        srx,
-                        mc_notify.clone(),
-                        metrics,
-                        metrics_interval,
-                        (worker_id - 1).try_into().unwrap(),
-                        aggr.unwrap(),
-                    );
-
-                    crate::runtime::block_on_local(&rt, local, async move {
-                        mc_notify.notified().await;
-                    });
-
-                    Python::attach(|_| drop(rt));
-                });
-                Some(thread)
-            } else {
-                mc_notify.notify_one();
-                None
-            };
-
-            for thread_id in 0..cfg.threads {
-                log::info!("Started worker-{} runtime-{}", worker_id, thread_id + 1);
-
-                let tcp_listener = cfg.$listener_gen();
-                let blocking_threads = cfg.blocking_threads;
-                let py_threads = cfg.py_threads;
-                let py_threads_idle_timeout = cfg.py_threads_idle_timeout;
-                let backpressure = cfg.backpressure;
-                let metrics = metrics.clone();
-                let ctx = ctx.clone();
-                let acceptor = acceptor.clone();
-                let handler = handler.clone();
-                let target = target.clone();
-                let py_loop = py_loop.clone();
-                let srx = srx.clone();
-
-                workers.push(std::thread::spawn(move || {
-                    let rt = crate::runtime::init_runtime_st(
-                        blocking_threads,
-                        py_threads,
-                        py_threads_idle_timeout,
-                        py_loop,
-                        metrics.1.clone(),
-                    );
-                    let rth = rt.handler();
-                    let wrk = crate::workers::Worker::new(ctx, acceptor, handler, rth, target, metrics.0);
-                    let local = tokio::task::LocalSet::new();
-
-                    crate::runtime::block_on_local(&rt, local, async move {
-                        wrk.clone().listen(srx, tcp_listener, backpressure).await;
-
-                        log::info!("Stopping worker-{} runtime-{}", worker_id, thread_id + 1);
-
-                        wrk.tasks.close();
-                        wrk.tasks.wait().await;
-
-                        Python::attach(|_| drop(wrk));
-                    });
-
-                    Python::attach(|_| drop(rt));
-                }));
-            }
-
-            let pysig = signal.clone_ref(py);
-            std::thread::spawn(move || {
-                let pyrx = pysig.get().rx.lock().unwrap().take().unwrap();
-                _ = pyrx.recv();
-                stx.send(true).unwrap();
-                log::info!("Stopping worker-{worker_id}");
-                while let Some(worker) = workers.pop() {
-                    worker.join().unwrap();
-                }
-                if let Some(thread) = metrics_thread {
-                    thread.join().unwrap();
-                }
-
-                Python::attach(|py| {
-                    _ = pysig.get().release(py);
-                    drop(pysig);
-                });
-            });
-
-            _ = signal.get().qs.call_method0(py, pyo3::intern!(py, "wait"));
-        }
-    };
-}
-
-serve_fn!(mt serve_mt, std::net::TcpListener, tcp_listener);
-serve_fn!(st serve_st, std::net::TcpListener, tcp_listener);
-#[cfg(unix)]
-serve_fn!(mt serve_mt_uds, std::os::unix::net::UnixListener, uds_listener);
-#[cfg(unix)]
-serve_fn!(st serve_st_uds, std::os::unix::net::UnixListener, uds_listener);


### PR DESCRIPTION
Backported from Granian 3.x

Specifically:
- unify `WorkerSignal` and `WorkerSignalSync` under a single pyclass
- unify `serve.rs` macros between wsgi and other protocols
- simplify embed Rust serve internals
- Python exposed `serve` is now unblocking
- move "wait" over serving responsibility to Python code

Should fix #875 #884