### PR TITLE
Fix lost condvar wakeup on mt worker shutdown

### DIFF
--- a/src/serve.rs
+++ b/src/serve.rs
@@ -107,8 +107,10 @@ macro_rules! serve_fn {
                 _ = stx.send(true);
 
                 let (lock, cvar) = &*cvar;
-                let done = lock.lock().unwrap();
-                let _done = cvar.wait(done);
+                let mut done = lock.lock().unwrap();
+                while !*done {
+                    done = cvar.wait(done).unwrap();
+                }
 
                 Python::attach(|py| {
                     _ = pysig.get().release(py);


### PR DESCRIPTION
Fixes the worker hanging on shutdown in the `mt` arm of `src/serve.rs`.

The shutdown thread waited on the condvar without checking the flag. The runtime task sets the flag and calls `notify_one()`. If it gets there first, the notification is lost, because `std::sync::Condvar` does not store one. The thread then sleeps forever, `release()` is never called, the Python loop never returns, and granian SIGKILLs the worker on `workers-kill-timeout`.

It now waits in a loop over the flag. `wait_while` would do the same in one line if you prefer that.

Without the fix the reproduction from #875 hung in every run, first hang between 105s and 795s. With it, nothing in 384 restarts over eight runs of 15 minutes.

I also built the branch with a three second sleep in that window to widen it. Without the fix the first restart hung, with the fix none of 40 did.

Fixes #900, the full write-up is there.