### PR TITLE
Import py-setproctitle right before use to avoid MacOS fork crash

### DIFF
--- a/benchmarks/vs.md
+++ b/benchmarks/vs.md
@@ -136,4 +136,3 @@ Granian is run with `--ws` and `--runtime-threads 2`.
 | 32 | Gunicorn Asgi | 3802710 | 366978 | 378446 |
 | 32 | Uvicorn H11 | 3163470 | 183706 | 189447 |
 | 32 | Hypercorn | N/A | N/A | N/A |
-

--- a/benchmarks/vs.md
+++ b/benchmarks/vs.md
@@ -136,3 +136,4 @@ Granian is run with `--ws` and `--runtime-threads 2`.
 | 32 | Gunicorn Asgi | 3802710 | 366978 | 378446 |
 | 32 | Uvicorn H11 | 3163470 | 183706 | 189447 |
 | 32 | Hypercorn | N/A | N/A | N/A |
+

--- a/granian/_imports.py
+++ b/granian/_imports.py
@@ -12,3 +12,13 @@ try:
     import watchfiles
 except ImportError:
     watchfiles = None
+
+
+def import_setproctitle():
+    # Importing before a fork can crash the forked child on macOS:
+    # (https://github.com/dvarrazzo/py-setproctitle/issues/127)
+    try:
+        import setproctitle
+    except ImportError:
+        return None
+    return setproctitle

--- a/granian/_imports.py
+++ b/granian/_imports.py
@@ -16,7 +16,7 @@ except ImportError:
 
 def import_setproctitle():
     # Importing before a fork can crash the forked child on macOS:
-    # (https://github.com/dvarrazzo/py-setproctitle/issues/127)
+    # https://github.com/dvarrazzo/py-setproctitle/issues/127
     try:
         import setproctitle
     except ImportError:

--- a/granian/_imports.py
+++ b/granian/_imports.py
@@ -9,11 +9,6 @@ except ImportError:
     dotenv = None
 
 try:
-    import setproctitle
-except ImportError:
-    setproctitle = None
-
-try:
     import watchfiles
 except ImportError:
     watchfiles = None

--- a/granian/server/common.py
+++ b/granian/server/common.py
@@ -14,7 +14,7 @@ from typing import Any, Generic, TypeVar
 
 from .._compat import _PY_312, _PYV
 from .._granian import MetricsAggregator, MetricsExporter, WorkerSignal
-from .._imports import dotenv, setproctitle, watchfiles
+from .._imports import dotenv, watchfiles
 from .._internal import build_env_loader, load_target
 from .._signals import set_main_signals
 from ..constants import HTTPModes, Interfaces, Loops, RuntimeModes, SSLProtocols, TaskImpl
@@ -676,6 +676,11 @@ class AbstractServer(Generic[WT]):
                 logger.info('Websockets are not supported on WSGI, ignoring')
             if self.http == HTTPModes.http2:
                 logger.info('Websockets are not supported on HTTP/2 only, ignoring')
+
+        try:
+            import setproctitle
+        except ImportError:
+            setproctitle = None
 
         if setproctitle is not None:
             self.process_name = self.process_name or (f'granian {self.interface} {self._bind_addr_fmt} {self.target}')

--- a/granian/server/common.py
+++ b/granian/server/common.py
@@ -14,7 +14,7 @@ from typing import Any, Generic, TypeVar
 
 from .._compat import _PY_312, _PYV
 from .._granian import MetricsAggregator, MetricsExporter, WorkerSignal
-from .._imports import dotenv, watchfiles
+from .._imports import dotenv, import_setproctitle, watchfiles
 from .._internal import build_env_loader, load_target
 from .._signals import set_main_signals
 from ..constants import HTTPModes, Interfaces, Loops, RuntimeModes, SSLProtocols, TaskImpl
@@ -677,10 +677,7 @@ class AbstractServer(Generic[WT]):
             if self.http == HTTPModes.http2:
                 logger.info('Websockets are not supported on HTTP/2 only, ignoring')
 
-        try:
-            import setproctitle
-        except ImportError:
-            setproctitle = None
+        setproctitle = import_setproctitle()
 
         if setproctitle is not None:
             self.process_name = self.process_name or (f'granian {self.interface} {self._bind_addr_fmt} {self.target}')

--- a/granian/server/mp.py
+++ b/granian/server/mp.py
@@ -36,7 +36,6 @@ from .common import (
     TaskImpl,
     configure_logging,
     logger,
-    setproctitle,
 )
 
 
@@ -74,7 +73,12 @@ class WorkerProcess(AbstractWorker):
             from granian._loops import loops
 
             if process_name:
-                setproctitle.setproctitle(f'{process_name} worker-{worker_id}')
+                try:
+                    import setproctitle
+                except ImportError:
+                    setproctitle = None
+                if setproctitle is not None:
+                    setproctitle.setproctitle(f'{process_name} worker-{worker_id}')
 
             configure_logging(log_level, log_config, log_enabled)
             load_env(env_files)

--- a/granian/server/mp.py
+++ b/granian/server/mp.py
@@ -19,6 +19,7 @@ from .._granian import (
     WorkerSignal,
     WSGIWorker,
 )
+from .._imports import import_setproctitle
 from .._internal import load_env
 from .._types import SSLCtx
 from ..asgi import LifespanProtocol, _callback_wrapper as _asgi_call_wrap
@@ -73,10 +74,7 @@ class WorkerProcess(AbstractWorker):
             from granian._loops import loops
 
             if process_name:
-                try:
-                    import setproctitle
-                except ImportError:
-                    setproctitle = None
+                setproctitle = import_setproctitle()
                 if setproctitle is not None:
                     setproctitle.setproctitle(f'{process_name} worker-{worker_id}')
 


### PR DESCRIPTION
## Description
There is an issue with py-setproctitle on MacOS where forking a new process and renaming causes a SEGFAULT.

A workaround is described in https://github.com/dvarrazzo/py-setproctitle/issues/127#issuecomment-3770132728: Import py-setproctitle right before using it which circumvents the issue. 

I've tested this on my company laptop which runs MacOS 26 and it works.


Hope Granian is okay with supporting this workaround. I'm open to suggestions on how to make this prettier.
