### PR TITLE
Wait for UDS test server readiness instead of a fixed 1.5s sleep

### DIFF
--- a/tests/test_uds.py
+++ b/tests/test_uds.py
@@ -1,8 +1,10 @@
 import asyncio
 import multiprocessing as mp
 import os
+import socket
 import stat
 import sys
+import time
 from contextlib import asynccontextmanager
 from functools import partial
 from pathlib import Path
@@ -14,6 +16,32 @@ from granian import Granian
 
 
 IS_WIN = sys.platform == 'win32'
+UDS_READY_TIMEOUT = 30.0
+UDS_READY_POLL_INTERVAL = 0.05
+
+
+async def _wait_until_uds_ready(path, timeout=UDS_READY_TIMEOUT, interval=UDS_READY_POLL_INTERVAL, proc=None):
+    sock_path = str(path)
+    deadline = time.monotonic() + timeout
+    last_err = None
+
+    while time.monotonic() < deadline:
+        if proc is not None and not proc.is_alive():
+            raise RuntimeError(f'UDS server process exited before {sock_path} became ready')
+
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            sock.settimeout(interval)
+            sock.connect(sock_path)
+            return
+        except OSError as exc:
+            last_err = exc
+        finally:
+            sock.close()
+
+        await asyncio.sleep(interval)
+
+    raise TimeoutError(f'UDS {sock_path} was not ready within {timeout}s: {last_err}')
 
 
 def _serve(**kwargs):
@@ -50,7 +78,7 @@ async def _server(
 
     proc = mp.get_context('spawn').Process(target=_serve, kwargs=kwargs)
     proc.start()
-    await asyncio.sleep(1.5)
+    await _wait_until_uds_ready(kwargs['uds'], proc=proc)
 
     try:
         yield
@@ -190,3 +218,60 @@ async def test_uds_default_file_permission(asgi_server, runtime_mode):
 async def test_uds_configurable_file_permission(asgi_server, runtime_mode):
     async with asgi_server(runtime_mode, ws=False, uds_permissions=0o666):
         assert stat.S_IMODE(os.stat('granian.sock').st_mode) == 0o666
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(IS_WIN, reason='no UDS on win')
+async def test_wait_until_uds_ready_returns_quickly_when_listening(tmp_path):
+    sock_path = tmp_path / 'live.sock'
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(str(sock_path))
+    listener.listen(1)
+    try:
+        started = time.monotonic()
+        await _wait_until_uds_ready(sock_path, timeout=5.0)
+        assert time.monotonic() - started < 0.5
+    finally:
+        listener.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(IS_WIN, reason='no UDS on win')
+async def test_wait_until_uds_ready_times_out_when_not_listening(tmp_path):
+    sock_path = tmp_path / 'missing.sock'
+    started = time.monotonic()
+    with pytest.raises(TimeoutError):
+        await _wait_until_uds_ready(sock_path, timeout=0.25, interval=0.05)
+    assert time.monotonic() - started >= 0.25
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(IS_WIN, reason='no UDS on win')
+async def test_wait_until_uds_ready_socket_file_is_not_enough(tmp_path):
+    sock_path = tmp_path / 'stale.sock'
+    sock_path.touch()
+    with pytest.raises(TimeoutError):
+        await _wait_until_uds_ready(sock_path, timeout=0.25, interval=0.05)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(IS_WIN, reason='no UDS on win')
+async def test_wait_until_uds_ready_polls_until_listener_accepts(tmp_path):
+    sock_path = tmp_path / 'delayed.sock'
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+
+    async def bind_later():
+        await asyncio.sleep(0.35)
+        listener.bind(str(sock_path))
+        listener.listen(1)
+
+    bind_task = asyncio.create_task(bind_later())
+    try:
+        started = time.monotonic()
+        await _wait_until_uds_ready(sock_path, timeout=5.0, interval=0.05)
+        elapsed = time.monotonic() - started
+        assert elapsed >= 0.3
+        assert elapsed < 2.0
+    finally:
+        await bind_task
+        listener.close()


### PR DESCRIPTION
## Problem

tests/test_uds.py spawned Granian and then slept a fixed 1.5 seconds before issuing HTTP requests over the Unix domain socket. On slower machines the UDS listener is often not accepting connections yet, so httpx fails with ConnectError. Fast machines paid the full 1.5s wait even when the socket was already ready.

This is a test-side race: the socket file can exist after bind while listen() has not completed.

## Change

Replace asyncio.sleep(1.5) with _wait_until_uds_ready(), which polls until a connect to the UDS succeeds. It returns as soon as the listener accepts a connection, times out after 30 seconds with a clear error, and fails early if the server process exits before the socket is ready. A leftover socket file is treated as not ready (connect must succeed).

Helper coverage (no Granian process required):

- Returns quickly when a listener is already up
- Times out when nothing is listening
- Times out when only a stale socket file exists
- Polls until a delayed bind/listen completes

Production server behavior is unchanged.

## How tested

- make format / make lint-python
- make build-dev
- pytest -v tests/test_uds.py (20 passed)

Fixes #855