### PR TITLE
Add Windows ARM64 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,8 +90,14 @@ jobs:
             target: x86_64
             interpreter: 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t pypy3.11
             allocator: mimalloc
+          - os: windows
+            target: aarch64
+            runner: windows-11-arm
+            # no PyPy nor CPython 3.10 builds available for win_arm64
+            interpreter: 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t
+            allocator: mimalloc
 
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.runner || format('{0}-latest', matrix.os) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,8 +113,14 @@ jobs:
             target: x86_64
             interpreter: 3.10 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t pypy3.11
             allocator: mimalloc
+          - os: windows
+            target: aarch64
+            runner: windows-11-arm
+            # no PyPy nor CPython 3.10 builds available for win_arm64
+            interpreter: 3.11 3.12 3.13 3.14 3.14t 3.15 3.15t
+            allocator: mimalloc
 
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.runner || format('{0}-latest', matrix.os) }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,12 +104,14 @@ jobs:
         make test
 
   windows:
-    runs-on: windows-latest
+    name: windows ${{ matrix.runner == 'windows-11-arm' && 'arm64' || 'x64' }} (${{ matrix.python-version }})
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
+        runner: [windows-latest, windows-11-arm]
         python-version:
         - '3.10'
         - '3.11'
@@ -119,9 +121,11 @@ jobs:
         - '3.14t'
         - '3.15'
         - '3.15t'
+        exclude:
+          # no CPython 3.10 build available for win_arm64
+          - runner: windows-11-arm
+            python-version: '3.10'
 
-    env:
-      UV_PYTHON: ${{ matrix.python-version }}
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
@@ -129,11 +133,17 @@ jobs:
     - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       with:
         enable-cache: false
-    - name: Install
+    - name: Resolve Python version request
+      # uv resolves bare requests to an emulated x86_64 build on Windows ARM64
       env:
-        UV_PYTHON: ${{ matrix.python-version }}
+        PY_VERSION: ${{ matrix.python-version }}
+        PY_ARCH: ${{ matrix.runner == 'windows-11-arm' && 'aarch64' || 'x86_64' }}
       run: |
-        uv python install "$UV_PYTHON"
+        $version = $env:PY_VERSION -replace 't$','+freethreaded'
+        "UV_PYTHON=cpython-$version-windows-$($env:PY_ARCH)-none" >> $env:GITHUB_ENV
+    - name: Install
+      run: |
+        uv python install $env:UV_PYTHON
         uv venv .venv
         uv sync --group all
         uv run --no-sync maturin develop --uv --features mimalloc


### PR DESCRIPTION
As the title says -- there was no existing issue/discussion about it, but it isn't a major change, so I figured I'd submit the patch.

I added Windows ARM64 to the tests as well, because I wanted to verify that everything works. However I do realize that the tests don't cover every OS/architecture combination, so I can remove those if needed.

There was a minor issue in the windows job of the test workflow: the `uv python install "$UV_PYTHON"` line was assuming bash-style syntax, but the default shell is actually pwsh, so `$UV_PYTHON` was resolving to an empty string (pwsh requires the `$env:` prefix to access env vars.)

You can see this in workflow runs [like this one](https://github.com/emmett-framework/granian/actions/runs/33498748570/job/99826892627#step:4:13) for example:
```
error: `` is not a valid Python download request; see `uv help python` for supported formats and `uv python list --only-downloads` for available versions
```

So even if I remove the tests for Windows ARM64, I can push a commit with just this fix.